### PR TITLE
Fix registration for VSIX

### DIFF
--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -47,7 +47,9 @@
       <ManifestResourceName>VSPackage</ManifestResourceName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <ProjectReference Include="..\LogProviders\LogProviders.csproj" />
+    <ProjectReference Include="..\LogProviders\LogProviders.csproj">
+      <Name>LogProviders</Name>
+    </ProjectReference>
     <VSCTCompile Include="ProjectSystemToolsPackage.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -6,10 +6,10 @@
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
-    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[15.4,]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[15.4,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Version="[15.4,]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[15.4,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -20,5 +20,6 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="LogProviders" Path="|LogProviders|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
When I added a DLL to fix versioning issues, I forgot to add it to MEF registration. Also, the VSIX is only compatible with 15.4 on up.