### PR TITLE
Add project type column.

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -89,7 +89,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
                         var defaultColumns = new List<ColumnState>
                         {
                             new ColumnState2(StandardTableColumnDefinitions.DetailsExpander, isVisible: true, width: 25),
-                            new ColumnState2(StandardTableColumnDefinitions.ProjectName, isVisible: true, width: 250),
+                            new ColumnState2(StandardTableColumnDefinitions.ProjectName, isVisible: true, width: 200),
+                            new ColumnState2(TableColumnNames.ProjectType, isVisible: true, width: 50),
                             new ColumnState2(TableColumnNames.Dimensions, isVisible: true, width: 100),
                             new ColumnState2(TableColumnNames.Targets, isVisible: true, width: 700),
                             new ColumnState2(TableColumnNames.DesignTime, isVisible: true, width: 100),
@@ -138,6 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
             {
                 StandardTableColumnDefinitions.DetailsExpander,
                 StandardTableColumnDefinitions.ProjectName,
+                TableColumnNames.ProjectType,
                 TableColumnNames.Dimensions,
                 TableColumnNames.Targets,
                 TableColumnNames.DesignTime,

--- a/src/ProjectSystemTools/BuildLogging/Model/Build.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Build.cs
@@ -23,15 +23,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
         public BuildStatus Status { get; private set; }
 
-        public string Project { get; }
+        public string ProjectPath { get; }
 
         public string LogPath { get; private set; }
 
-        public string Filename => $"{Project}_{Dimensions.Aggregate((c, n) => string.IsNullOrEmpty(n) ? c : $"{c}_{n}")}_{(DesignTime ? "design" : "")}_{StartTime:s}.binlog".Replace(':', '_');
+        public string Filename => $"{Path.GetFileNameWithoutExtension(ProjectPath)}_{Dimensions.Aggregate((c, n) => string.IsNullOrEmpty(n) ? c : $"{c}_{n}")}_{(DesignTime ? "design" : "")}_{StartTime:s}.binlog".Replace(':', '_');
 
-        public Build(string project, IEnumerable<string> dimensions, IEnumerable<string> targets, bool designTime, DateTime startTime)
+        public Build(string projectPath, IEnumerable<string> dimensions, IEnumerable<string> targets, bool designTime, DateTime startTime)
         {
-            Project = project;
+            ProjectPath = projectPath;
             Dimensions = dimensions.ToArray();
             Targets = targets?.ToArray() ?? Enumerable.Empty<string>();
             DesignTime = designTime;
@@ -75,7 +75,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
                     break;
 
                 case StandardTableKeyNames.ProjectName:
-                    content = Project;
+                    content = Path.GetFileNameWithoutExtension(ProjectPath);
+                    break;
+
+                case TableKeyNames.ProjectType:
+                    content = Path.GetExtension(ProjectPath);
                     break;
 
                 case TableKeyNames.StartTime:
@@ -111,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
             }
 
             var startComparison = StartTime.CompareTo(other.StartTime);
-            return startComparison != 0 ? startComparison : String.Compare(Project, other.Project, StringComparison.Ordinal);
+            return startComparison != 0 ? startComparison : String.Compare(ProjectPath, other.ProjectPath, StringComparison.Ordinal);
         }
 
         public void Dispose()

--- a/src/ProjectSystemTools/BuildLogging/Model/BuildTableLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildTableLogger.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
             var dimensions = GatherDimensions(e.GlobalProperties);
 
-            var build = new Build(Path.GetFileNameWithoutExtension(e.ProjectFile), dimensions.ToArray(), e.TargetNames?.Split(';'), _isDesignTime, e.Timestamp);
+            var build = new Build(e.ProjectFile, dimensions.ToArray(), e.TargetNames?.Split(';'), _isDesignTime, e.Timestamp);
             _build = build;
             _projectInstanceId = e.BuildEventContext.ProjectInstanceId;
             _dataSource.AddEntry(_build);

--- a/src/ProjectSystemTools/BuildLogging/Resources.resx
+++ b/src/ProjectSystemTools/BuildLogging/Resources.resx
@@ -135,6 +135,9 @@
   <data name="OpenCommand" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="ProjectTypeHeaderLabel" xml:space="preserve">
+    <value>Type</value>
+  </data>
   <data name="SearchWatermark" xml:space="preserve">
     <value>Search Build Logs</value>
   </data>

--- a/src/ProjectSystemTools/BuildLogging/UI/ProjectTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/ProjectTypeColumnDefinition.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(TableColumnNames.ProjectType)]
+    internal sealed class ProjectTypeColumnDefinition : TableColumnDefinitionBase
+    {
+        public override string Name => TableColumnNames.ProjectType;
+
+        public override string DisplayName => Resources.ProjectTypeHeaderLabel;
+
+        public override StringComparer Comparer => StringComparer.Ordinal;
+
+        public override double MinWidth => 50.0;
+
+        public override TextWrapping TextWrapping => TextWrapping.NoWrap;
+
+        public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
+        {
+            if (entry.TryGetValue(TableKeyNames.ProjectType, out var value) && value != null && value is string projectType)
+            {
+                content = projectType;
+                return true;
+            }
+
+            content = null;
+            return false;
+        }
+    }
+}

--- a/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
@@ -8,5 +8,6 @@
         public const string Elapsed = "elapsed";
         public const string Status = "status";
         public const string Targets = "targets";
+        public const string ProjectType = "projecttype";
     }
 }

--- a/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
@@ -13,5 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
         public const string Targets = "targets";
         public const string LogPath = "logpath";
         public const string Filename = "filename";
+        public const string ProjectType = "projecttype";
     }
 }

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.cs.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.cs.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.de.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.de.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.es.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.es.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.fr.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.fr.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.it.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.it.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ja.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ja.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ko.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ko.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.pl.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.pl.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.pt-BR.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ru.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ru.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.tr.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.tr.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hans.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hant.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="new">Targets</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
When logging a mixed solution, it can be helpful to see what the type of the project is (.vcxproj, .vbproj, .csproj) so you can sort/filter on it.