### PR TITLE
Add csproj evaluation logging

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
+{
+    [Flags]
+    internal enum BuildType
+    {
+        None = 0x0,
+        Build = 0x1,
+        DesignTimeBuild = 0x2,
+        Evaluation = 0x4
+    }
+}

--- a/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 {

--- a/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
@@ -2,61 +2,109 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 {
-    internal sealed class EvaluationLogger : ILogger
+    internal sealed class EvaluationLogger : LoggerBase
     {
-        private readonly BuildTableDataSource _dataSource;
-        private readonly Dictionary<int, Build> _evaluations = new Dictionary<int, Build>();
-
-        public LoggerVerbosity Verbosity { get => LoggerVerbosity.Diagnostic; set { } }
-
-        public string Parameters { get; set; }
-
-        public EvaluationLogger(BuildTableDataSource dataSource)
+        private sealed class EventWrapper : IEventSource
         {
-            _dataSource = dataSource;
+            public BinaryLogger BinaryLogger { get; }
+
+            public event BuildMessageEventHandler MessageRaised { add { } remove { } }
+            public event BuildErrorEventHandler ErrorRaised { add { } remove { } }
+            public event BuildWarningEventHandler WarningRaised { add { } remove { } }
+            public event BuildStartedEventHandler BuildStarted { add { } remove { } }
+            public event BuildFinishedEventHandler BuildFinished { add { } remove { } }
+            public event ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+            public event ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+            public event TargetStartedEventHandler TargetStarted { add { } remove { } }
+            public event TargetFinishedEventHandler TargetFinished { add { } remove { } }
+            public event TaskStartedEventHandler TaskStarted { add { } remove { } }
+            public event TaskFinishedEventHandler TaskFinished { add { } remove { } }
+            public event CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+            public event BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+            public event AnyEventHandler AnyEventRaised;
+
+            public EventWrapper(BinaryLogger binaryLogger)
+            {
+                BinaryLogger = binaryLogger;
+                BinaryLogger.Initialize(this);
+            }
+
+            public void RaiseEvent(object sender, BuildEventArgs args) => AnyEventRaised?.Invoke(sender, args);
         }
 
-        public void Initialize(IEventSource eventSource)
+        private readonly Dictionary<int, (EventWrapper, Build, string)> _evaluations = new Dictionary<int, (EventWrapper, Build, string)>();
+
+        public EvaluationLogger(BuildTableDataSource dataSource) :
+            base(dataSource)
         {
-            eventSource.StatusEventRaised += StatusEvent;
         }
 
-        private void StatusEvent(object sender, BuildStatusEventArgs args)
+        public override void Initialize(IEventSource eventSource)
         {
+            eventSource.AnyEventRaised += AnyEvent;
+        }
+
+        private void AnyEvent(object sender, BuildEventArgs args)
+        {
+            if (args.BuildEventContext.EvaluationId == BuildEventContext.InvalidEvaluationId)
+            {
+                return;
+            }
+
             switch (args)
             {
                 case ProjectEvaluationStartedEventArgs evaluationStarted:
                     {
-                        if (!_dataSource.IsLogging)
+                        if (!DataSource.IsLogging || evaluationStarted.ProjectFile == "(null)")
                         {
                             return;
                         }
 
-                        var build = new Build(evaluationStarted.ProjectFile, Array.Empty<string>(), new[] {"<Evaluation>"}, 
-                            false, args.Timestamp);
-                        _evaluations[evaluationStarted.BuildEventContext.EvaluationId] = build;
-                        _dataSource.AddEntry(build);
+                        var logPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.binlog");
+                        var binaryLogger = new BinaryLogger
+                        {
+                            Parameters = logPath,
+                            Verbosity = LoggerVerbosity.Diagnostic,
+                            CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.None
+                        };
+                        var wrapper = new EventWrapper(binaryLogger);
+                        var build = new Build(evaluationStarted.ProjectFile, Array.Empty<string>(), Array.Empty<string>(), 
+                            BuildType.Evaluation, args.Timestamp);
+                        _evaluations[evaluationStarted.BuildEventContext.EvaluationId] = (wrapper, build, logPath);
+                        wrapper.RaiseEvent(sender, args);
+                        DataSource.AddEntry(build);
                     }
                     break;
 
                 case ProjectEvaluationFinishedEventArgs evaluationFinished:
                     {
-                        if (_evaluations.TryGetValue(evaluationFinished.BuildEventContext.EvaluationId, out var build))
+                        if (_evaluations.TryGetValue(args.BuildEventContext.EvaluationId, out var tuple))
                         {
-                            build.Finish(true, args.Timestamp, null);
-                            _dataSource.NotifyChange();
+                            var (wrapper, build, logPath) = tuple;
+                            build.Finish(true, args.Timestamp, logPath);
+                            wrapper.RaiseEvent(sender, args);
+                            wrapper.BinaryLogger.Shutdown();
+                            DataSource.NotifyChange();
+                        }
+                    }
+                    break;
+
+                default:
+                    {
+                        if (_evaluations.TryGetValue(args.BuildEventContext.EvaluationId, out var tuple))
+                        {
+                            var (wrapper, build, logPath) = tuple;
+                            wrapper.RaiseEvent(sender, args);
                         }
                     }
                     break;
             }
-        }
-
-        public void Shutdown()
-        {
         }
     }
 }

--- a/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
+{
+    internal sealed class EvaluationLogger : ILogger
+    {
+        private readonly BuildTableDataSource _dataSource;
+        private readonly Dictionary<int, Build> _evaluations = new Dictionary<int, Build>();
+
+        public LoggerVerbosity Verbosity { get => LoggerVerbosity.Diagnostic; set { } }
+
+        public string Parameters { get; set; }
+
+        public EvaluationLogger(BuildTableDataSource dataSource)
+        {
+            _dataSource = dataSource;
+        }
+
+        public void Initialize(IEventSource eventSource)
+        {
+            eventSource.StatusEventRaised += StatusEvent;
+        }
+
+        private void StatusEvent(object sender, BuildStatusEventArgs args)
+        {
+            switch (args)
+            {
+                case ProjectEvaluationStartedEventArgs evaluationStarted:
+                    {
+                        if (!_dataSource.IsLogging)
+                        {
+                            return;
+                        }
+
+                        var build = new Build(evaluationStarted.ProjectFile, Array.Empty<string>(), new[] {"<Evaluation>"}, 
+                            false, args.Timestamp);
+                        _evaluations[evaluationStarted.BuildEventContext.EvaluationId] = build;
+                        _dataSource.AddEntry(build);
+                    }
+                    break;
+
+                case ProjectEvaluationFinishedEventArgs evaluationFinished:
+                    {
+                        if (_evaluations.TryGetValue(evaluationFinished.BuildEventContext.EvaluationId, out var build))
+                        {
+                            build.Finish(true, args.Timestamp, null);
+                            _dataSource.NotifyChange();
+                        }
+                    }
+                    break;
+            }
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+}

--- a/src/ProjectSystemTools/BuildLogging/Model/LoggerBase.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/LoggerBase.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Build.Framework;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
+{
+    internal abstract class LoggerBase : ILogger
+    {
+        protected readonly BuildTableDataSource DataSource;
+
+        public LoggerVerbosity Verbosity { get => LoggerVerbosity.Diagnostic; set { } }
+
+        public string Parameters { get; set; }
+
+        protected LoggerBase(BuildTableDataSource dataSource)
+        {
+            DataSource = dataSource;
+        }
+
+        public abstract void Initialize(IEventSource eventSource);
+
+        public virtual void Shutdown()
+        {
+        }
+    }
+}

--- a/src/ProjectSystemTools/BuildLogging/Model/LoggerBase.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/LoggerBase.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Build.Framework;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.Build.Framework;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 {

--- a/src/ProjectSystemTools/BuildLogging/Model/ProjectLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/ProjectLogger.cs
@@ -9,7 +9,7 @@ using Microsoft.Build.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 {
-    internal sealed class BuildTableLogger : ILogger
+    internal sealed class ProjectLogger : ILogger
     {
         private static readonly string[] Dimensions = {"Configuration", "Platform", "TargetFramework"};
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
         public string Parameters { get; set; }
 
-        public BuildTableLogger(BuildTableDataSource dataSource, bool isDesignTime)
+        public ProjectLogger(BuildTableDataSource dataSource, bool isDesignTime)
         {
             _dataSource = dataSource;
             _isDesignTime = isDesignTime;

--- a/src/ProjectSystemTools/BuildLogging/Resources.resx
+++ b/src/ProjectSystemTools/BuildLogging/Resources.resx
@@ -117,17 +117,29 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BuildTypeHeaderLabel" xml:space="preserve">
+    <value>Type</value>
+  </data>
   <data name="CannotSetProperty" xml:space="preserve">
     <value>Cannot set property.</value>
-  </data>
-  <data name="DesignTimeHeaderLabel" xml:space="preserve">
-    <value>Design-Time</value>
   </data>
   <data name="DimensionsHeaderLabel" xml:space="preserve">
     <value>Dimensions</value>
   </data>
   <data name="ElapsedHeaderLabel" xml:space="preserve">
     <value>Elapsed</value>
+  </data>
+  <data name="FilterBuildAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="FilterBuildBuilds" xml:space="preserve">
+    <value>Builds</value>
+  </data>
+  <data name="FilterBuildDesignTimeBuilds" xml:space="preserve">
+    <value>Design-time Builds</value>
+  </data>
+  <data name="FilterBuildEvaluations" xml:space="preserve">
+    <value>Evaluation</value>
   </data>
   <data name="LogFolderDescription" xml:space="preserve">
     <value>Save logs to:</value>

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildTypeColumnDefinition.cs
@@ -3,18 +3,19 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Windows;
+using Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 {
     [Export(typeof(ITableColumnDefinition))]
-    [Name(TableColumnNames.DesignTime)]
-    internal sealed class DesignTimeColumnDefinition : TableColumnDefinitionBase
+    [Name(TableColumnNames.BuildType)]
+    internal sealed class BuildTypeColumnDefinition : TableColumnDefinitionBase
     {
-        public override string Name => TableColumnNames.DesignTime;
+        public override string Name => TableColumnNames.BuildType;
 
-        public override string DisplayName => Resources.DesignTimeHeaderLabel;
+        public override string DisplayName => Resources.BuildTypeHeaderLabel;
 
         public override StringComparer Comparer => StringComparer.Ordinal;
 
@@ -24,9 +25,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.DesignTime, out var value) && value != null && value is bool isDesignTime)
+            if (entry.TryGetValue(TableKeyNames.BuildType, out var value) && value != null && value is BuildType buildType)
             {
-                content = isDesignTime.ToString();
+                content = buildType.ToString();
                 return true;
             }
 

--- a/src/ProjectSystemTools/BuildLogging/UI/DimensionsColumnDefinition.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/DimensionsColumnDefinition.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;

--- a/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 {
     internal static class TableColumnNames
     {

--- a/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableColumnNames.cs
@@ -2,7 +2,7 @@
 {
     internal static class TableColumnNames
     {
-        public const string DesignTime = "designtime";
+        public const string BuildType = "buildtype";
         public const string StartTime = "starttime";
         public const string Dimensions = "dimensions";
         public const string Elapsed = "elapsed";

--- a/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
@@ -4,7 +4,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 {
     internal static class TableKeyNames
     {
-        public const string DesignTime = "designtime";
+        public const string BuildType = "buildtype";
         public const string StartTime = "starttime";
         public const string OperationTime = "operationtime";
         public const string Dimensions = "dimensions";

--- a/src/ProjectSystemTools/BuildLogging/UI/TargetsColumnDefinition.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TargetsColumnDefinition.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.cs.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.cs.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.de.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.de.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.es.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.es.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.fr.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.fr.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.it.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.it.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ja.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ja.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ko.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ko.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.pl.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.pl.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.pt-BR.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.ru.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.ru.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.tr.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.tr.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hans.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hant.xlf
+++ b/src/ProjectSystemTools/BuildLogging/xlf/Resources.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="new">Cannot set property.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DesignTimeHeaderLabel">
-        <source>Design-Time</source>
-        <target state="new">Design-Time</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DimensionsHeaderLabel">
         <source>Dimensions</source>
         <target state="new">Dimensions</target>
@@ -55,6 +50,31 @@
       <trans-unit id="ProjectTypeHeaderLabel">
         <source>Type</source>
         <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildTypeHeaderLabel">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildAll">
+        <source>All</source>
+        <target state="new">All</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildBuilds">
+        <source>Builds</source>
+        <target state="new">Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildDesignTimeBuilds">
+        <source>Design-time Builds</source>
+        <target state="new">Design-time Builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterBuildEvaluations">
+        <source>Evaluation</source>
+        <target state="new">Evaluation</target>
         <note />
       </trans-unit>
     </body>

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
         public const int ClearCommandId = 0x0103;
         public const int SaveLogsCommandId = 0x0107;
         public const int OpenLogsCommandId = 0x0108;
+        public const int BuildTypeComboCommandId = 0x0109;
+        public const int BuildTypeComboGetListCommandId = 0x010a;
 
         public static readonly Guid UIGuid = new Guid("629080DF-2A44-40E5-9AF4-371D4B727D16");
 

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
@@ -67,6 +67,13 @@
         </Strings>
       </Button>
     </Buttons>
+    <Combos>
+      <Combo guid="CommandSetGuid" id="BuildTypeComboCommandId" defaultWidth="150" type="DropDownCombo" idCommandList="BuildTypeComboGetListCommandId">
+        <Strings>
+          <ButtonText>Choose build types</ButtonText>
+        </Strings>
+      </Combo>
+    </Combos>
   </Commands>
   <CommandPlacements>
     <CommandPlacement guid="CommandSetGuid" id="BuildLoggingCommandId" priority="0x0100">
@@ -79,6 +86,9 @@
       <Parent guid="UIGuid" id="BuildLoggingToolbarGroupId" />
     </CommandPlacement>
     <CommandPlacement guid="CommandSetGuid" id="ClearCommandId" priority="0x0000">
+      <Parent guid="UIGuid" id="BuildLoggingToolbarGroupId" />
+    </CommandPlacement>
+    <CommandPlacement guid="CommandSetGuid" id="BuildTypeComboCommandId" priority="0x0000">
       <Parent guid="UIGuid" id="BuildLoggingToolbarGroupId" />
     </CommandPlacement>
     <CommandPlacement guid="CommandSetGuid" id="SaveLogsCommandId" priority="0x0000">
@@ -97,6 +107,8 @@
       <IDSymbol name="ClearCommandId" value="0x0103" />
       <IDSymbol name="SaveLogsCommandId" value="0x0107" />
       <IDSymbol name="OpenLogsCommandId" value="0x0108" />
+      <IDSymbol name="BuildTypeComboCommandId" value="0x0109"/>
+      <IDSymbol name="BuildTypeComboGetListCommandId" value="0x010a"/>
     </GuidSymbol>
     <GuidSymbol name="UIGuid" value="{629080DF-2A44-40E5-9AF4-371D4B727D16}">
       <IDSymbol name="BuildLoggingToolbarMenuId" value="0x0100" />

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="new">Open Logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildTypeComboCommandId|ButtonText">
+        <source>Choose build types</source>
+        <target state="new">Choose build types</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This adds logging for project evaluations to the build logging window. Since evaluations in the project system happen separately from design-time and regular builds, this gives an additional window into delays that may be caused by project design.

It also adds a dropdown in the toolbar that allows easily filtering by Evaluation, Build or Design-Time Build.

Logging CPS evaluations requires, unfortunately, CPS to add a public API to allow it.
