### PR TITLE
Move to non-guid filenames for captured logs

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -300,11 +300,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
             foreach (var entry in _tableControl.SelectedEntries)
             {
-                if (!entry.TryGetValue(TableKeyNames.LogPath, out string logPath) ||
-                    !entry.TryGetValue(TableKeyNames.Filename, out string filename))
+                if (!entry.TryGetValue(TableKeyNames.LogPath, out string logPath))
                 {
                     continue;
                 }
+
+                var filename = Path.GetFileName(logPath);
+
+                if (filename == null)
+                {
+                    continue;
+                }
+
                 try
                 {
                     File.Copy(logPath, Path.Combine(folderBrowser.SelectedPath, filename));

--- a/src/ProjectSystemTools/BuildLogging/Model/Build.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Build.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
                 ? $"{Dimensions.Aggregate((c, n) => string.IsNullOrEmpty(n) ? c : $"{c}_{n}")}_"
                 : string.Empty;
 
-        public string Filename => $"{Path.GetFileNameWithoutExtension(ProjectPath)}_{DimensionsString}{BuildType}_{StartTime:o}.binlog".Replace(':', '_');
+        private string Filename => $"{Path.GetFileNameWithoutExtension(ProjectPath)}_{DimensionsString}{BuildType}_{StartTime:o}.binlog".Replace(':', '_');
 
         public Build(string projectPath, IEnumerable<string> dimensions, IEnumerable<string> targets, BuildType buildType, DateTime startTime)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
             StartTime = startTime;
         }
 
-        public void Finish(bool succeeded, DateTime time, string logPath)
+        public void Finish(bool succeeded, DateTime time)
         {
             if (Status != BuildStatus.Running)
             {
@@ -52,7 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
             Status = succeeded ? BuildStatus.Finished : BuildStatus.Failed;
             Elapsed = time - StartTime;
-            LogPath = logPath;
+        }
+
+        public void Close(string logPath)
+        {
+            LogPath = Path.Combine(Path.GetTempPath(), Filename);
+            File.Copy(logPath, LogPath, true);
         }
 
         public bool TryGetValue(string keyName, out object content)
@@ -93,10 +98,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
                 case TableKeyNames.LogPath:
                     content = LogPath;
-                    break;
-
-                case TableKeyNames.Filename:
-                    content = Filename;
                     break;
 
                 default:

--- a/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
@@ -98,9 +98,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
                     {
                         if (_evaluations.TryGetValue(args.BuildEventContext.EvaluationId, out var evaluation))
                         {
-                            evaluation.Build.Finish(true, args.Timestamp, evaluation.LogPath);
+                            evaluation.Build.Finish(true, args.Timestamp);
                             evaluation.Wrapper.RaiseEvent(sender, args);
                             evaluation.Wrapper.BinaryLogger.Shutdown();
+                            evaluation.Build.Close(evaluation.LogPath);
                             DataSource.NotifyChange();
                         }
                     }

--- a/src/ProjectSystemTools/BuildLogging/Model/ProjectLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/ProjectLogger.cs
@@ -42,6 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
         public override void Shutdown()
         {
             _binaryLogger.Shutdown();
+            _build.Close(_logPath);
+            DataSource.NotifyChange();
         }
 
         private void ProjectFinished(object sender, ProjectFinishedEventArgs e)
@@ -51,8 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
                 return;
             }
 
-            _build.Finish(e.Succeeded, e.Timestamp, _logPath);
-            DataSource.NotifyChange();
+            _build.Finish(e.Succeeded, e.Timestamp);
         }
 
         private static IEnumerable<string> GatherDimensions(IDictionary<string, string> globalProperties)

--- a/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/TableKeyNames.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
         public const string Status = "status";
         public const string Targets = "targets";
         public const string LogPath = "logpath";
-        public const string Filename = "filename";
         public const string ProjectType = "projecttype";
     }
 }


### PR DESCRIPTION
Right now when we capture logs, we save them to a guid filename in the temp directory until you save them somewhere. For some future feature, it would be better to have the regular filename the whole time, and that seems reasonable since the log can't be interacted with until the build is actually finished anyway.