### PR TITLE
Add support for querying properties and output groups

### DIFF
--- a/src/ProjectSystemTools/ProjectQuery/ProjectQueryDialog.xaml
+++ b/src/ProjectSystemTools/ProjectQuery/ProjectQueryDialog.xaml
@@ -1,0 +1,56 @@
+﻿<ui:DialogWindow x:Class="Microsoft.VisualStudio.ProjectSystem.Tools.ProjectQuery.ProjectQueryDialog"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+                 xmlns:local="clr-namespace:Microsoft.VisualStudio.ProjectSystem.Tools.ProjectQuery"
+                 mc:Ignorable="d"
+                 x:ClassModifier="internal"
+                 SizeToContent="WidthAndHeight"
+                 ResizeMode="NoResize">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="5" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="5" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="5" />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="5" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" MinHeight="5"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Name="MessageBlock"
+               Grid.Column="1" Grid.Row="1"
+               Grid.ColumnSpan="4"
+               TextWrapping="Wrap"
+               Width="300">
+        </TextBlock>
+
+        <TextBox Name="InputField"
+             Grid.Column="1" Grid.Row="3"
+             Grid.ColumnSpan="4"
+             Width="300" />
+
+        <Button Grid.Column="2" Grid.Row="5"
+            Width="50"
+            IsDefault="True"
+            Click="OnOKButton">
+            OK
+        </Button>
+        <Button Grid.Column="4" Grid.Row="5"
+            Width="50"
+            Click="OnCancelButton">
+            Cancel
+        </Button>
+    </Grid>
+</ui:DialogWindow>

--- a/src/ProjectSystemTools/ProjectQuery/ProjectQueryDialog.xaml.cs
+++ b/src/ProjectSystemTools/ProjectQuery/ProjectQueryDialog.xaml.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Windows;
+using Microsoft.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tools.ProjectQuery
+{
+    /// <summary>
+    /// Interaction logic for ProjectQueryDialog.xaml
+    /// </summary>
+    internal partial class ProjectQueryDialog : DialogWindow
+    {
+        public ProjectQueryDialog(string title, string message)
+        {
+            InitializeComponent();
+
+            Title = title;
+            MessageBlock.Text = message;
+
+            InputField.Focus();
+        }
+
+        private void OnOKButton(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void OnCancelButton(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -12,6 +12,8 @@
     <ExtensionInstallationFolder>Microsoft\ProjectSystemTools</ExtensionInstallationFolder>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EnvDTE" Version="8.0.2" />
+    <PackageReference Include="EnvDTE80" Version="8.0.2" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildEngineVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
@@ -72,10 +74,17 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="ProjectQuery\ProjectQueryDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="BuildLogExplorer\BuildTreeViewControl.xaml.cs">
       <DependentUpon>BuildTreeViewControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="ProjectQuery\ProjectQueryDialog.xaml.cs">
+      <DependentUpon>ProjectQueryDialog.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -1,19 +1,22 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.VisualStudio.Shell;
-using Task = System.Threading.Tasks.Task;
-using System.ComponentModel.Design;
+using EnvDTE;
+using EnvDTE80;
 using Microsoft.Internal.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogExplorer;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging;
+using Microsoft.VisualStudio.ProjectSystem.Tools.ProjectQuery;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableManager;
-using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools
 {
@@ -42,6 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
         public const int ExploreLogsCommandId = 0x0109;
         public const int AddLogCommandId = 0x010a;
         public const int MessageListCommandId = 0x010b;
+        public const int QueryMSBuildPropertyCommandId = 0x010c;
+        public const int QueryOutputGroupCommandId = 0x010d;
 
         public static readonly Guid UIGuid = new Guid("629080DF-2A44-40E5-9AF4-371D4B727D16");
 
@@ -53,14 +58,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
         private BuildLoggingToolWindow _buildLoggingToolWindow;
         private BuildLogExplorerToolWindow _buildLogExplorerToolWindow;
 
+        private OutputWindowPane _projectQueryOutputWindowPane;
+
         public static IServiceProvider ServiceProvider { get; private set; }
 
         public BuildLoggingToolWindow BuildLoggingToolWindow => _buildLoggingToolWindow ?? (_buildLoggingToolWindow = (BuildLoggingToolWindow)FindToolWindow(typeof(BuildLoggingToolWindow), 0, true));
         public BuildLogExplorerToolWindow BuildLogExplorerToolWindow => _buildLogExplorerToolWindow ?? (_buildLogExplorerToolWindow = (BuildLogExplorerToolWindow)FindToolWindow(typeof(BuildLogExplorerToolWindow), 0, true));
 
+        public OutputWindowPane ProjectQueryOutputPane => _projectQueryOutputWindowPane ?? (_projectQueryOutputWindowPane = (DTE.ToolWindows.OutputWindow.OutputWindowPanes.Add("Project Query")));
+
         public static IVsUIShell VsUIShell { get; private set; }
 
         public static IVsFindManager VsFindManager { get; private set; }
+
+        private static DTE2 DTE { get; set; }
 
         public static ProjectSystemToolsPackage Instance;
 
@@ -83,6 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
             VsUIShell = GetService(typeof(IVsUIShell)) as IVsUIShell;
             VsFindManager = GetService(typeof(SVsFindManager)) as IVsFindManager;
+            DTE = GetService(typeof(SDTE)) as DTE2;
 
             var componentModel = GetService(typeof(SComponentModel)) as IComponentModel;
             TableControlProvider = componentModel?.GetService<IWpfTableControlProvider>();
@@ -92,6 +104,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
             mcs?.AddCommand(new MenuCommand(ShowBuildLoggingToolWindow, new CommandID(CommandSetGuid, BuildLoggingCommandId)));
             mcs?.AddCommand(new MenuCommand(ShowBuildLogExplorerToolWindow, new CommandID(CommandSetGuid, BuildLogExplorerCommandId)));
             mcs?.AddCommand(new MenuCommand(ShowMessageListToolWindow, new CommandID(CommandSetGuid, MessageListCommandId)));
+            mcs?.AddCommand(new MenuCommand(QueryMSBuildProperty, new CommandID(CommandSetGuid, QueryMSBuildPropertyCommandId)));
+            mcs?.AddCommand(new MenuCommand(QueryOutputGroup, new CommandID(CommandSetGuid, QueryOutputGroupCommandId)));
 
             Instance = this;
         }
@@ -136,6 +150,106 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
             var windowFrame = (IVsWindowFrame)window.Frame;
             ErrorHandler.ThrowOnFailure(windowFrame.Show());
+        }
+
+        private void QueryMSBuildProperty(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var dialog = new ProjectQueryDialog("Get MSBuild Property", "Retrieves the value of an MSBuild property via the project's IVsBuildPropertyStorage implementation.");
+
+            var retrieveProperty = dialog.ShowModal();
+            if (!retrieveProperty.HasValue
+                || !retrieveProperty.Value)
+            {
+                return;
+            }
+
+            ProjectQueryOutputPane.Activate();
+            ShowOutputWindow();
+
+            var propertyName = dialog.InputField.Text;
+
+            var solution = GetService(typeof(SVsSolution)) as IVsSolution;
+            if (solution == null)
+            {
+                return;
+            }
+
+            var guid = Guid.Empty;
+            if (solution.GetProjectEnum((uint)__VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION, ref guid, out IEnumHierarchies hierarchies) == VSConstants.S_OK)
+            {
+                var hierarchyArray = new IVsHierarchy[1];
+                while (hierarchies.Next((uint)hierarchyArray.Length, hierarchyArray, out uint fetched) == 0
+                        && fetched > 0)
+                {
+                    if (hierarchyArray[0] is IVsBuildPropertyStorage buildPropertyStorage
+                        && buildPropertyStorage.GetPropertyValue(propertyName, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out string propertyValue) == VSConstants.S_OK
+                        && hierarchyArray[0].GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out object projectNameObject) == VSConstants.S_OK)
+                    {
+                        var projectName = (string)projectNameObject;
+                        ProjectQueryOutputPane.OutputString($"$({propertyName}) in {projectName} = {propertyValue}\r\n");
+                    }
+                }
+            }
+        }
+
+        private void QueryOutputGroup(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var dialog = new ProjectQueryDialog("Get Output Group", "Retrieves the list of items in the specified output group.");
+
+            var retrieveOutputGroup = dialog.ShowModal();
+            if (!retrieveOutputGroup.HasValue
+                || !retrieveOutputGroup.Value)
+            {
+                return;
+            }
+
+            ProjectQueryOutputPane.Activate();
+            ShowOutputWindow();
+
+            var outputGroupName = dialog.InputField.Text;
+            foreach (Project project in DTE.Solution.Projects)
+            {
+                var configurationManager = project.ConfigurationManager;
+                if (configurationManager == null)
+                {
+                    return;
+                }
+
+                var activeConfiguration = configurationManager.ActiveConfiguration;
+                if (activeConfiguration == null)
+                {
+                    return;
+                }
+
+                var outputGroups = activeConfiguration.OutputGroups;
+                if (outputGroups == null)
+                {
+                    return;
+                }
+
+                var outputGroup = outputGroups.Item(outputGroupName);
+                if (outputGroup == null)
+                {
+                    return;
+                }
+
+                ProjectQueryOutputPane.OutputString($"Output group '{outputGroupName}' in project {project.Name}:\r\n");
+                Array fileNames = (Array)outputGroup.FileNames;
+                foreach (string fileName in fileNames)
+                {
+                    ProjectQueryOutputPane.OutputString($"  {fileName}\r\n");
+                }
+            };
+        }
+
+        private void ShowOutputWindow()
+        {
+            var outputWindow = DTE.Windows.Item(EnvDTE.Constants.vsWindowKindOutput);
+            outputWindow.Activate();
         }
     }
 }

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
@@ -47,6 +47,9 @@
       <Group guid="UIGuid" id="MessageListToolbarGroupId" priority="0x0000">
         <Parent guid="UIGuid" id="MessageListToolbarMenuId"/>
       </Group>
+      <Group guid="UIGuid" id="ProjectQueryCommandGroupId" priority="0x0200">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS"/>
+      </Group>
     </Groups>
     <Buttons>
       <Button guid="CommandSetGuid" id="BuildLoggingCommandId" type="Button">
@@ -111,6 +114,16 @@
           <ButtonText>Build Log Message List</ButtonText>
         </Strings>
       </Button>
+      <Button guid="CommandSetGuid" id="QueryMSBuildPropertyCommandId" type="Button">
+        <Strings>
+          <ButtonText>Get MSBuild Property...</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="CommandSetGuid" id="QueryOutputGroupCommandId" type="Button">
+        <Strings>
+          <ButtonText>Get Output Group...</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Combos>
       <Combo guid="CommandSetGuid" id="BuildTypeComboCommandId" defaultWidth="150" type="DropDownCombo" idCommandList="BuildTypeComboGetListCommandId">
@@ -166,6 +179,12 @@
     <CommandPlacement guid="guidVSStd2K" id="cmdidErrorListShowMessages" priority="0x0100">
       <Parent guid="UIGuid" id="MessageListToolbarGroupId"/>
     </CommandPlacement>
+    <CommandPlacement guid="CommandSetGuid" id="QueryMSBuildPropertyCommandId" priority="0x0010">
+      <Parent guid="UIGuid" id="ProjectQueryCommandGroupId"/>
+    </CommandPlacement>
+    <CommandPlacement guid="CommandSetGuid" id="QueryOutputGroupCommandId" priority="0x0020">
+      <Parent guid="UIGuid" id="ProjectQueryCommandGroupId"/>
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <GuidSymbol name="PackageGuid" value="{e3bfb509-b8fd-4692-b4c4-4b2f6ed62bc7}" />
@@ -182,6 +201,8 @@
       <IDSymbol name="ExploreLogsCommandId" value="0x0109"/>
       <IDSymbol name="AddLogCommandId" value="0x010a"/>
       <IDSymbol name="MessageListCommandId" value="0x010b" />
+      <IDSymbol name="QueryMSBuildPropertyCommandId" value="0x010c" />
+      <IDSymbol name="QueryOutputGroupCommandId" value="0x010d" />
     </GuidSymbol>
     <GuidSymbol name="UIGuid" value="{629080DF-2A44-40E5-9AF4-371D4B727D16}">
       <IDSymbol name="BuildLoggingToolbarMenuId" value="0x0100" />
@@ -193,6 +214,7 @@
       <IDSymbol name="MessageListToolbarMenuId" value="0x0106" />
       <IDSymbol name="MessageListToolbarGroupId" value="0x0107" />
       <IDSymbol name="WindowCommandGroupId" value="0x0108" />
+      <IDSymbol name="ProjectQueryCommandGroupId" value="0x0109" />
     </GuidSymbol>
     <GuidSymbol name="ImageCatalogGuid" value="{ae27a6b0-e345-4288-96df-5eaf394ee369}">
       <IDSymbol name="Play" value="2356" />

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
@@ -32,6 +32,9 @@
       </Menu>
     </Menus>
     <Groups>
+      <Group guid="UIGuid" id="WindowCommandGroupId" priority="0x0100">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_WINDOWS" />
+      </Group>
       <Group guid="UIGuid" id="BuildLoggingToolbarGroupId" priority="0x0000">
         <Parent guid="UIGuid" id="BuildLoggingToolbarMenuId"/>
       </Group>
@@ -118,8 +121,8 @@
     </Combos>
   </Commands>
   <CommandPlacements>
-    <CommandPlacement guid="CommandSetGuid" id="BuildLoggingCommandId" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
+    <CommandPlacement guid="CommandSetGuid" id="BuildLoggingCommandId" priority="0x0010">
+      <Parent guid="UIGuid" id="WindowCommandGroupId" />
     </CommandPlacement>
     <CommandPlacement guid="CommandSetGuid" id="StartLoggingCommandId" priority="0x0000">
       <Parent guid="UIGuid" id="BuildLoggingToolbarGroupId" />
@@ -142,8 +145,8 @@
     <CommandPlacement guid="CommandSetGuid" id="ExploreLogsCommandId" priority="0x0020">
       <Parent guid="UIGuid" id="BuildLoggingContextGroupId"/>
     </CommandPlacement>
-    <CommandPlacement guid="CommandSetGuid" id="BuildLogExplorerCommandId" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
+    <CommandPlacement guid="CommandSetGuid" id="BuildLogExplorerCommandId" priority="0x0020">
+      <Parent guid="UIGuid" id="WindowCommandGroupId" />
     </CommandPlacement>
     <CommandPlacement guid="CommandSetGuid" id="AddLogCommandId" priority="0x0000">
       <Parent guid="UIGuid" id="BuildLogExplorerToolbarGroupId" />
@@ -151,8 +154,8 @@
     <CommandPlacement guid="CommandSetGuid" id="ClearCommandId" priority="0x0010">
       <Parent guid="UIGuid" id="BuildLogExplorerToolbarGroupId" />
     </CommandPlacement>
-    <CommandPlacement guid="CommandSetGuid" id="MessageListCommandId" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
+    <CommandPlacement guid="CommandSetGuid" id="MessageListCommandId" priority="0x0030">
+      <Parent guid="UIGuid" id="WindowCommandGroupId" />
     </CommandPlacement>
     <CommandPlacement guid="guidVSStd2K" id="cmdidErrorListShowErrors" priority="0x0100">
       <Parent guid="UIGuid" id="MessageListToolbarGroupId"/>
@@ -189,6 +192,7 @@
       <IDSymbol name="BuildLogExplorerToolbarGroupId" value="0x0105" />
       <IDSymbol name="MessageListToolbarMenuId" value="0x0106" />
       <IDSymbol name="MessageListToolbarGroupId" value="0x0107" />
+      <IDSymbol name="WindowCommandGroupId" value="0x0108" />
     </GuidSymbol>
     <GuidSymbol name="ImageCatalogGuid" value="{ae27a6b0-e345-4288-96df-5eaf394ee369}">
       <IDSymbol name="Play" value="2356" />

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
@@ -97,6 +97,16 @@
         <target state="new">Build Log Message List</target>
         <note />
       </trans-unit>
+      <trans-unit id="QueryMSBuildPropertyCommandId|ButtonText">
+        <source>Get MSBuild Property...</source>
+        <target state="new">Get MSBuild Property...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QueryOutputGroupCommandId|ButtonText">
+        <source>Get Output Group...</source>
+        <target state="new">Get Output Group...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This change adds support for querying MSBuild properties and output groups. A couple of new menu items, "Get MSBuild Property..." and "Get Output Group...", have been added to the Tools menu. Selecting one of these pops up a dialog box where the name of a property or output group can be entered. The results are then displayed in a dedicated pane in the Output Window.

In the current implementation we query each project in the solution, rather than having the user pick one. Querying for MSBuild properties goes through the `IVsBuildPropertyStorage` interface, and the output groups are retrieved through the `EnvDTE.ConfigurationManager` interface.

Still to fix:

 - [ ] Move strings to .resx files.
 - [ ] Figure out how to get the dialog boxes to show in a rational location. Currently they display in the upper-left corner of the screen.
 - [ ] Add exception handling around the calls into the VS APIs.
 - [ ] Figure out the best way to limit the query to a particular project. Querying all projects isn't that useful and can create a lot of output.