### PR TITLE
Make build work in Dev16

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -160,7 +160,11 @@ try {
   $ToolsetBuildProj = Join-Path $NuGetPackageRoot "RoslynTools.RepoToolset\$ToolsetVersion\tools\Build.proj"
 
   $vsInstallDir = LocateVisualStudio
-  $MsbuildExe = Join-Path $vsInstallDir "MSBuild\Current\Bin\msbuild.exe"
+  if ($InVS16Environment) {
+    $MsbuildExe = Join-Path $vsInstallDir "MSBuild\Current\Bin\msbuild.exe"
+  } else {
+    $MsbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+  }
 
   if ($ci) {
     Create-Directory $TempDir

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -73,8 +73,12 @@ function GetVersion([string] $name) {
 }
 
 function LocateVisualStudio {
-  if ($InVSEnvironment) {
+  if ($InVS16Environment) {
     return Join-Path $env:VS160COMNTOOLS "..\.."
+  }
+
+  if ($InVS15Environment) {
+    return Join-Path $env:VS150COMNTOOLS "..\.."
   }
 
   $vswhereVersion = GetVersion("VSWhereVersion")
@@ -131,7 +135,8 @@ function Clear-NuGetCache() {
 }
 
 try {
-  $InVSEnvironment = !($env:VS160COMNTOOLS -eq $null) -and (Test-Path $env:VS160COMNTOOLS)
+  $InVS15Environment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
+  $InVS16Environment = !($env:VS160COMNTOOLS -eq $null) -and (Test-Path $env:VS160COMNTOOLS)
   $RepoRoot = Join-Path $PSScriptRoot "..\"
   $ToolsRoot = Join-Path $RepoRoot ".tools"
   $ToolsetRestoreProj = Join-Path $PSScriptRoot "Toolset.proj"
@@ -165,9 +170,10 @@ try {
     Write-Host "Using $MsbuildExe"
   }
 
-  if (!$InVSEnvironment) {
-    $env:VS160COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
-    $env:VSSDK160Install = Join-Path $vsInstallDir "VSSDK\"
+  if (!$InVS15Environment -and !$InVS16Environment) {
+    # If we're not in a VS shell, assume Dev15
+    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
+    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
     $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
   }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -74,7 +74,7 @@ function GetVersion([string] $name) {
 
 function LocateVisualStudio {
   if ($InVSEnvironment) {
-    return Join-Path $env:VS150COMNTOOLS "..\.."
+    return Join-Path $env:VS160COMNTOOLS "..\.."
   }
 
   $vswhereVersion = GetVersion("VSWhereVersion")
@@ -131,7 +131,7 @@ function Clear-NuGetCache() {
 }
 
 try {
-  $InVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
+  $InVSEnvironment = !($env:VS160COMNTOOLS -eq $null) -and (Test-Path $env:VS160COMNTOOLS)
   $RepoRoot = Join-Path $PSScriptRoot "..\"
   $ToolsRoot = Join-Path $RepoRoot ".tools"
   $ToolsetRestoreProj = Join-Path $PSScriptRoot "Toolset.proj"
@@ -155,7 +155,7 @@ try {
   $ToolsetBuildProj = Join-Path $NuGetPackageRoot "RoslynTools.RepoToolset\$ToolsetVersion\tools\Build.proj"
 
   $vsInstallDir = LocateVisualStudio
-  $MsbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+  $MsbuildExe = Join-Path $vsInstallDir "MSBuild\Current\Bin\msbuild.exe"
 
   if ($ci) {
     Create-Directory $TempDir
@@ -166,8 +166,8 @@ try {
   }
 
   if (!$InVSEnvironment) {
-    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
-    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
+    $env:VS160COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
+    $env:VSSDK160Install = Join-Path $vsInstallDir "VSSDK\"
     $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
   }
 


### PR DESCRIPTION
This makes the build.cmd script work with Dev16 which is our new baseline.