### PR TITLE
Fix error when built-in editor isn't the default

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -21,7 +21,7 @@ using DialogResult = System.Windows.Forms.DialogResult;
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 {
     [Guid(BuildLoggingToolWindowGuidString)]
-    internal sealed class BuildLoggingToolWindow : TableToolWindow 
+    internal sealed class BuildLoggingToolWindow : TableToolWindow
     {
         public const string BuildLogging = "BuildLogging";
         public const string BuildLoggingToolWindowGuidString = "391238ea-dad7-488c-94d1-e2b6b5172bf3";
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
             var guid = VSConstants.LOGVIEWID_Primary;
             _openDocument.OpenDocumentViaProject(logPath, ref guid, out _, out _, out _, out var frame);
-            frame.Show();
+            frame?.Show();
         }
 
         private static void ShowExceptionMessageDialog(Exception e, string title)


### PR DESCRIPTION
While I still want to see an option to choose which editor to use as part of this extension (#64), this fixes the `NullReferenceException` that happens if you've manually changed the default editor as described in https://github.com/dotnet/project-system-tools/issues/64#issuecomment-463569397.

@panopticoncentral It would be great if you could get this merged and released! The error this fixes is incredibly annoying! 😄 