### PR TITLE
Fix the extension's ability to load and F5

### DIFF
--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -10,6 +10,7 @@
     <!-- VSIX -->
     <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
     <ExtensionInstallationFolder>Microsoft\ProjectSystemTools</ExtensionInstallationFolder>
+    <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />

--- a/src/ProjectSystemTools/Properties/launchSettings.json
+++ b/src/ProjectSystemTools/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ProjectSystemTools": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootsuffix RoslynDev /log"
+      "commandLineArgs": "/rootsuffix Exp /log"
     }
   }
 }


### PR DESCRIPTION
Two changes:

1. Ensure we set UseCodebase=true so the package can be loaded.
2. Make sure we F5 to the correct Visual Studio hive so things load.