### PR TITLE
Add external viewer back

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -237,6 +238,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
             frame?.Show();
         }
 
+        private void OpenLogsExternal()
+        {
+            foreach (var entry in TableControl.SelectedEntries)
+            {
+                if (!entry.TryGetValue(TableKeyNames.LogPath, out string logPath))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Process.Start(logPath);
+                }
+                catch (Exception e)
+                {
+                    var title = $"Error opening {Path.GetFileName(logPath)}";
+                    ShowExceptionMessageDialog(e, title);
+                }
+            }
+        }
+
         private static void ShowExceptionMessageDialog(Exception e, string title)
         {
             var message = $@"{e.GetType().FullName}
@@ -351,6 +373,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
                 case ProjectSystemToolsPackage.OpenLogsCommandId:
                     OpenLogs();
+                    break;
+
+                case ProjectSystemToolsPackage.OpenLogsExternalCommandId:
+                    OpenLogsExternal();
                     break;
 
                 case ProjectSystemToolsPackage.BuildTypeComboCommandId:

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
         public const int BuildTypeComboCommandId = 0x0106;
         public const int BuildTypeComboGetListCommandId = 0x0107;
         public const int MessageListCommandId = 0x010b;
+        public const int OpenLogsExternalCommandId = 0x010c;
 
         public const int LogRoslynWorkspaceStructureCommandId = 0x0200;
 

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
@@ -75,6 +75,11 @@
           <ButtonText>Open Logs...</ButtonText>
         </Strings>
       </Button>
+      <Button guid="CommandSetGuid" id="OpenLogsExternalCommandId" type="Button">
+        <Strings>
+          <ButtonText>Open Logs External...</ButtonText>
+        </Strings>
+      </Button>
       <Button guid="CommandSetGuid" id="MessageListCommandId" type="Button">
         <Strings>
           <ButtonText>Build Log Message List</ButtonText>
@@ -116,6 +121,9 @@
     <CommandPlacement guid="CommandSetGuid" id="OpenLogsCommandId" priority="0x0010">
       <Parent guid="UIGuid" id="BuildLoggingContextGroupId" />
     </CommandPlacement>
+    <CommandPlacement guid="CommandSetGuid" id="OpenLogsExternalCommandId" priority="0x0020">
+      <Parent guid="UIGuid" id="BuildLoggingContextGroupId" />
+    </CommandPlacement>
     <CommandPlacement guid="CommandSetGuid" id="MessageListCommandId" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
     </CommandPlacement>
@@ -144,6 +152,7 @@
       <IDSymbol name="BuildTypeComboCommandId" value="0x0106"/>
       <IDSymbol name="BuildTypeComboGetListCommandId" value="0x0107"/>
       <IDSymbol name="MessageListCommandId" value="0x010b" />
+      <IDSymbol name="OpenLogsExternalCommandId" value="0x010c" />
       <IDSymbol name="LogRoslynWorkspaceStructureCommandId" value="0x0200"/>
     </GuidSymbol>
     <GuidSymbol name="UIGuid" value="{629080DF-2A44-40E5-9AF4-371D4B727D16}">

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.cs.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.de.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.es.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.fr.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.it.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ja.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ko.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pl.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.ru.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.tr.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>

--- a/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
+++ b/src/ProjectSystemTools/xlf/ProjectSystemToolsPackage.vsct.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="new">Log Roslyn Workplace Structure...</target>
         <note />
       </trans-unit>
+      <trans-unit id="OpenLogsExternalCommandId|ButtonText">
+        <source>Open Logs External...</source>
+        <target state="new">Open Logs External...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StartLoggingCommandId|ButtonText">
         <source>Start logging</source>
         <target state="new">Start logging</target>


### PR DESCRIPTION
This adds an "Open log external" item that restores the ability to easily open the binlog in the MSBuild Structured Log Viewer. In response to #64.