### PR TITLE
Lop off unneeded microseconds

### DIFF
--- a/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
@@ -25,11 +25,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.Status, out var statusValue) && statusValue != null && statusValue is BuildStatus status &&
-                status != BuildStatus.Running &&
-                entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value != null && value is TimeSpan timeSpan)
+            if (entry.TryGetValue(TableKeyNames.Status, out var statusValue) && statusValue != null && statusValue is BuildStatus status
+                && status != BuildStatus.Running
+                && entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value != null && value is TimeSpan timeSpan)
             {
-                content = timeSpan.ToString("g");
+                content = timeSpan.ToString(@"hh\:mm\:ss\:ff");
                 return true;
             }
 


### PR DESCRIPTION
This is in response to the old issue #31, asking to remove some of the unneeded precision for elapsed time, which seemed reasonable...