### PR TITLE
Targets tooltip

### DIFF
--- a/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Windows;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Utilities;
@@ -30,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
                 value is IEnumerable<string> targets &&
                 targets.Any())
             {
-                content = targets.Aggregate((current, next) => $"{current};{next}");
+                content = string.Join(";", targets);
                 return true;
             }
 

--- a/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
@@ -25,9 +25,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.Targets, out var value) && value != null &&
-                value is IEnumerable<string> targets &&
-                targets.Any())
+            if (entry.TryGetValue(TableKeyNames.Targets, out var value) &&
+                value is IEnumerable<string> targets)
             {
                 content = string.Join(";", targets);
                 return true;

--- a/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
@@ -35,5 +35,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             content = null;
             return false;
         }
+
+        public override bool TryCreateToolTip(ITableEntryHandle entry, out object toolTip)
+        {
+            if (entry.TryGetValue(TableKeyNames.Targets, out var value) &&
+                value is IEnumerable<string> targets)
+            {
+                toolTip = string.Join(Environment.NewLine, targets);
+                return true;
+            }
+
+            return base.TryCreateToolTip(entry, out toolTip);
+        }
     }
 }


### PR DESCRIPTION
Often there are very many targets and it's hard to see them all. This change adds a tool tip which has each target on its own line making it easier to browse.

![image](https://user-images.githubusercontent.com/350947/60594784-0ea2c580-9de9-11e9-96a6-d4f6fc675eac.png)
