### PR TITLE
Ignore events that don't have an BuildEventContext

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/EvaluationLogger.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 
         private void AnyEvent(object sender, BuildEventArgs args)
         {
-            if (args.BuildEventContext.EvaluationId == BuildEventContext.InvalidEvaluationId)
+            if (args.BuildEventContext == null || args.BuildEventContext.EvaluationId == BuildEventContext.InvalidEvaluationId)
             {
                 return;
             }


### PR DESCRIPTION
Fixes the issue in https://github.com/dotnet/project-system/issues/5665 where having build logging turned on means the the first build silently fails.