### PR TITLE
Append build status to saved log file name

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -206,6 +206,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
                     continue;
                 }
 
+                if (entry.TryGetValue(TableKeyNames.Status, out string status))
+                {
+                    // Status is defined by enum BuildStatus with members: Running, Finished or Failed
+                    filename = $"{filename}_{CapitalizeFailed(status)}";
+                }
+
                 try
                 {
                     File.Copy(logPath, Path.Combine(folderBrowser.SelectedPath, filename));
@@ -215,6 +221,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
                     var title = $"Error saving {filename}";
                     ShowExceptionMessageDialog(e, title);
                 }
+            }
+
+            return;
+
+            static string CapitalizeFailed(string status)
+            {
+                if (StringComparer.Ordinal.Equals(status, BuildStatus.Failed.ToString()))
+                {
+                    return "FAILED";
+                }
+
+                return status;
             }
         }
 


### PR DESCRIPTION
When a customer reports an error from a large solution, there can be many projects which will be attached to a ticket. Often most of them succeeded and you're looking for the lone failure among them. This creates an extra delay loop with the customer when you ask which of the logs is failing if there are hundreds of files.

This change appends the build status string to the file name so you can quickly find failures or hangs among a batch of logs.

---

Motivated as a solution to a problem experience in this feedback ticket:

https://developercommunity.visualstudio.com/content/problem/865870/non-deterministic-intellisense-issues-with-aspnet.html?childToView=902601#comment-902601