### PR TITLE
Revert "change uri to a secret"

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -15,4 +15,4 @@ jobs:
         uses: davidwengier/PostAdaptiveCard@v1.0.0
         if: github.repository == 'dotnet/project-system-tools'
         with:
-          webhook-uri: ${{ secrets.TeamsWebhook }}
+          webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/9a07b7d0343f4f25b1c138f52a38a2be/9dbc0cfc-eab3-42c9-838a-4879bef6875e


### PR DESCRIPTION
Reverts dotnet/project-system-tools#332

Having the uri in a secret doesn't seem to be working