### PR TITLE
Remove if statement since webhook is now a secret

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,5 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.0
-        if: github.repository == 'dotnet/project-system-tools'
         with:
           webhook-uri: ${{ secrets.TeamsWebhook }}


### PR DESCRIPTION
We used this if statement in order to avoid getting updates in our Teams only when PRs were created in the main repo (we didn't want them coming from forks).
Since we moved to using a different URI and it's now stored as a secret, secrets don't get copied to forks so we won't see this problem anymore.