### PR TITLE
Update how search bar switches from worker thread to use UI thread

### DIFF
--- a/src/ProjectSystemTools/TableControl/TableSearchTask.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchTask.cs
@@ -18,16 +18,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         protected override void OnStartSearch()
         {
-            ThreadHelper.Generic.BeginInvoke(delegate(){
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 _control.SetFilter(TableToolWindow.SearchFilterKey, new TableSearchFilter(SearchQuery, _control));
-                }
-            );
-            SearchCallback.ReportComplete(this, dwResultsFound: 0);
+
+                SearchCallback.ReportComplete(this, dwResultsFound: 0);
+            });
         }
 
         protected override void OnStopSearch()
         {
-            _control.SetFilter(TableToolWindow.SearchFilterKey, null);
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                
+                _control.SetFilter(TableToolWindow.SearchFilterKey, null);
+            });
         }
     }
 }


### PR DESCRIPTION
Related to: https://github.com/dotnet/project-system-tools/pull/330

Context:
- Previous implementation (ThreadHelper.Generic.BeginInvoke()) is potentially vulnerable to thread pool exhaustion
- BeginInvoke() will also cause an editor warning when porting this repo into project-system

Changes:
- Switch out BeginInvoke() for new pattern
- Add UI thread waiting logic to OnStopSearch(), since that function also uses SetFilter()
- SetFilter is required to run on UI thread, https://github.com/dotnet/project-system-tools/pull/330