### PR TITLE
Remove notifications from dotnet-maestro[bot]

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.0
-        if: github.repository == 'dotnet/project-system-tools'
+        if: github.repository == 'dotnet/project-system-tools' && github.actor != 'dmonroym'
         with:
           webhook-uri: ${{ secrets.TeamsWebhook }}


### PR DESCRIPTION
The merges from dotnet-maestro should happen automatically and seamlessly so this'll reduce the noise in our teams channel