### PR TITLE
Remove notifications from dotnet-maestro[bot]

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system-tools'
+        if: github.repository == 'dotnet/project-system-tools' && github.actor != 'dmonroym'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: Notify
         uses: davidwengier/PostAdaptiveCard@v1.0.1
-        if: github.repository == 'dotnet/project-system-tools' && github.actor != 'dmonroym'
+        if: github.repository == 'dotnet/project-system-tools' && github.actor != 'dotnet-maestro[bot]'
         with:
           webhook-uri: https://outlook.office.com/webhook/4ba7372f-2799-4677-89f0-7a1aaea3706c@72f988bf-86f1-41af-91ab-2d7cd011db47/IncomingWebhook/461ee56585254d63b67f15afdf6a1513/b4e5dfd6-185f-4aed-90e3-aa15b6f398ba


### PR DESCRIPTION
The merges from dotnet-maestro should happen automatically and seamlessly so this'll reduce the noise in our teams channel