### PR TITLE
Support async tool windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -78,3 +78,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+# VSTHRD010: Invoke single-threaded types on Main thread
+# TODO upgrade this to warning or error in future
+dotnet_diagnostic.VSTHRD010.severity = suggestion

--- a/ProjectSystemTools.sln
+++ b/ProjectSystemTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26913.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30711.63
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectSystemTools", "src\ProjectSystemTools\ProjectSystemTools.csproj", "{4ADB9F32-E622-4EAA-8DF8-C6D9298FE0EB}"
 EndProject

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,25 +9,29 @@
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <!-- MSBuild -->
-    <MicrosoftBuildVersion>15.6.85</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>16.8.0</MicrosoftBuildVersion>
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.0.0</MicrosoftVisualStudioLanguageServicesVersion>
     <!-- VS SDK -->
-    <MicrosoftVisualStudioComponentModelHostVersion>15.4.27004</MicrosoftVisualStudioComponentModelHostVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>15.4.27004</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioImageCatalogVersion>15.4.27004</MicrosoftVisualStudioImageCatalogVersion>
-    <MicrosoftVisualStudioEditorVersion>15.4.27004</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>16.8.239</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioCoreUtilityVersion>16.8.239</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVisualStudioEditorVersion>16.8.239</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioImageCatalogVersion>16.8.30709.132</MicrosoftVisualStudioImageCatalogVersion>
+    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>16.8.30705.32</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioProjectSystemSDKVersion>15.3.224</MicrosoftVisualStudioProjectSystemSDKVersion>
-    <MicrosoftVisualStudioShell150Version>15.4.27004</MicrosoftVisualStudioShell150Version>
-    <MicrosoftVisualStudioShellFrameworkVersion>15.4.27004</MicrosoftVisualStudioShellFrameworkVersion>
-    <MicrosoftVisualStudioShellInterop140DesignTimeVersion>15.0.25726-Preview5</MicrosoftVisualStudioShellInterop140DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop150DesignTimeVersion>15.0.26932</MicrosoftVisualStudioShellInterop150DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop153DesignTimeVersion>15.0.26929</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
-    <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop100Version>
-    <MicrosoftVisualStudioUtilitiesVersion>15.4.27004</MicrosoftVisualStudioUtilitiesVersion>
+    <MicrosoftVisualStudioShell150Version>16.8.30406.155-pre</MicrosoftVisualStudioShell150Version>
+    <MicrosoftVisualStudioShellFrameworkVersion>16.8.30406.155-pre</MicrosoftVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioShellInterop140DesignTimeVersion>16.8.30406.65</MicrosoftVisualStudioShellInterop140DesignTimeVersion>
+    <MicrosoftVisualStudioShellInterop150DesignTimeVersion>16.8.30406.65</MicrosoftVisualStudioShellInterop150DesignTimeVersion>
+    <MicrosoftVisualStudioShellInterop153DesignTimeVersion>16.8.30406.65</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
+    <MicrosoftVisualStudioShellInterop90Version>16.8.30406.65</MicrosoftVisualStudioShellInterop90Version>
+    <MicrosoftVisualStudioTextManagerInterop100Version>16.8.30705.32</MicrosoftVisualStudioTextManagerInterop100Version>
+    <MicrosoftVisualStudioThreadingVersion>16.8.55</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioUtilitiesVersion>16.8.30406.65-pre</MicrosoftVisualStudioUtilitiesVersion>
+    <VSLangProjVersion>7.0.3301</VSLangProjVersion>
     <!-- Libs -->
     <SystemCompositionVersion>1.1.0</SystemCompositionVersion>
+    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -15,7 +15,7 @@ pr:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     _os: Windows
   strategy:

--- a/src/LogModel/LogModel.csproj
+++ b/src/LogModel/LogModel.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LogModel/LogModel.csproj
+++ b/src/LogModel/LogModel.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>Microsoft.VisualStudio.ProjectSystem.LogModel</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.ProjectSystem.LogModel</AssemblyName>
     <IsProductComponent>false</IsProductComponent>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LogProviders/LogProviders.csproj
+++ b/src/LogProviders/LogProviders.csproj
@@ -6,10 +6,6 @@
     <IsProductComponent>false</IsProductComponent>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />

--- a/src/LogProviders/LogProviders.csproj
+++ b/src/LogProviders/LogProviders.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
@@ -26,7 +26,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 </Project>

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
@@ -37,9 +38,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
-    <PackageReference Include="VSLangProj" Version="7.0.3301" />
+    <PackageReference Include="VSLangProj" Version="$(VSLangProjVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -15,7 +15,7 @@
     <!-- Disable warnings if there is a mismach of Embed Interop types. The Roslyn packages references some shell
          binaries without it, but Microsoft.VisualStudio.SDK.EmbedInteropTypes turns it on. Silencing the warning will
          mean we won't embed the things already not being embedded, but that's harmless. -->
-    <NoWarn>1762</NoWarn>
+    <NoWarn>$(NoWarn);1762</NoWarn>
 
     <!-- Work around dotnet/wpf#1718 for the time being -->
     <EmbedUntrackedSources>false</EmbedUntrackedSources>

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -87,14 +87,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
             PackageTaskCollection = ThreadHelper.JoinableTaskContext.CreateCollection();
             PackageTaskFactory = ThreadHelper.JoinableTaskContext.CreateFactory(PackageTaskCollection);
 
-            VsUIShell = GetService(typeof(IVsUIShell)) as IVsUIShell;
-            VsFindManager = GetService(typeof(SVsFindManager)) as IVsFindManager;
+            VsUIShell = await GetServiceAsync(typeof(IVsUIShell)) as IVsUIShell;
+            VsFindManager = await GetServiceAsync(typeof(SVsFindManager)) as IVsFindManager;
 
-            var componentModel = GetService(typeof(SComponentModel)) as IComponentModel;
+            var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
             TableControlProvider = componentModel?.GetService<IWpfTableControlProvider>();
             TableManagerProvider = componentModel?.GetService<ITableManagerProvider>();
 
-            var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            var mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
             mcs?.AddCommand(new MenuCommand(ShowBuildLoggingToolWindow, new CommandID(CommandSetGuid, BuildLoggingCommandId)));
             mcs?.AddCommand(new MenuCommand(ShowMessageListToolWindow, new CommandID(CommandSetGuid, MessageListCommandId)));
             mcs?.AddCommand(new MenuCommand(LogRoslynWorkspaceStructure, new CommandID(CommandSetGuid, LogRoslynWorkspaceStructureCommandId)));

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 using System.ComponentModel.Design;
+using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor;
@@ -144,5 +145,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
             RoslynLogging.RoslynWorkspaceStructureLogger.ShowSaveDialogAndLog(ServiceProvider);
         }
 
+        public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
+        {
+            if (toolWindowType == typeof(MessageListToolWindow).GUID ||
+                toolWindowType == typeof(BuildLoggingToolWindow).GUID)
+            {
+                return this;
+            }
+
+            return base.GetAsyncToolWindowFactory(toolWindowType);
+        }
+
+        protected override string GetToolWindowTitle(Type toolWindowType, int id)
+        {
+            if (toolWindowType == typeof(MessageListToolWindow))
+            {
+                return BinaryLogEditorResources.MessageListWindowTitle;
+            }
+
+            if (toolWindowType == typeof(BuildLoggingToolWindow))
+            {
+                return BuildLoggingResources.BuildLogWindowTitle;
+            }
+
+            return base.GetToolWindowTitle(toolWindowType, id);
+        }
+
+        protected override Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<object>(null);
+        }
     }
 }

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
@@ -38,9 +39,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
             // Show context menu blocks, so we need to yield out of this method
             // for e.Handled to be noticed by WPF
-            Dispatcher.BeginInvoke(new Action(() =>
-                ProjectSystemToolsPackage.VsUIShell.ShowContextMenu(0, ref guidContextMenu, _contextMenuId,
-                    locationPoints, pCmdTrgtActive: null)));
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                ProjectSystemToolsPackage.VsUIShell.ShowContextMenu(
+                    0, ref guidContextMenu, _contextMenuId,
+                    locationPoints, pCmdTrgtActive: null);
+            });
         }
 
         // Default to the bottom-left corner of the control for the position of context menu invoked from keyboard

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
                     locationPoints, pCmdTrgtActive: null)));
         }
 
-        // Default to the bottom-left corner of the control for the position of contect menu invoked from keyboard
+        // Default to the bottom-left corner of the control for the position of context menu invoked from keyboard
         private Point GetKeyboardContextMenuAnchorPoint() => PointToScreen(new Point(0, RenderSize.Height));
 
         // Get the current mouse position and convert it to screen coordinates as the shell expects a screen position

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="B6213233-1C34-4F76-9DD5-F6D520C32AA3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Project System Tools</DisplayName>
+    <DisplayName>Project System Tools 2019</DisplayName>
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
     <Icon>Icon.png</Icon>
     <PreviewImage>Icon.png</PreviewImage>

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -9,13 +9,13 @@
     <Tags>project, csproj, vbproj</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.0,)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.0,)" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
   </Dependencies>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/6768

This allows VS to defer initialising tool windows when VS is loading, which improves start up performance.

Async tool windows were introduced in VS16, so this PR increases the minimum VS version for this extension from 15 to 16.
