### PR TITLE
Create new extension for VS2017

### DIFF
--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="B6213233-1C34-4F76-9DD5-F6D520C32AA3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Project System Tools</DisplayName>
+    <Identity Id="51AA3C54-2C40-4543-A75B-392A7ED660FF" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Project System Tools 2017</DisplayName>
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
     <Icon>Icon.png</Icon>
     <PreviewImage>Icon.png</PreviewImage>
     <Tags>project, csproj, vbproj</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,16.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
The `master` branch has been updated to require VS2019. This `vs-2017` branch will target VS2017 only.

This PR adds "2017" to the name, and updates version ranges to exclude VS2019 and later.