### PR TITLE
Support Visual Studio 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bld/
 
 # build tools that are created by repo-toolset
 .tools/
+.packages/
 
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,16 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-eng"    value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet-tools"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <!--
+    <add key="dotnet5"       value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;" />
+    <add key="myget-legacy"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;" />
+    <add key="vs-impl"       value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;" />
+    <add key="vssdk"         value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;" />
+    <add key="dotnet-core"   value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;" />
+    -->
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,12 +5,12 @@
     <add key="dotnet-eng"    value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet5"       value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="vssdk"         value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl"       value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <!--
-    <add key="dotnet5"       value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;" />
-    <add key="myget-legacy"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;" />
-    <add key="vs-impl"       value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;" />
-    <add key="vssdk"         value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;" />
-    <add key="dotnet-core"   value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;" />
+    <add key="myget-legacy"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="dotnet-core"   value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     -->
   </packageSources>
   <disabledPackageSources />

--- a/ProjectSystemTools.sln
+++ b/ProjectSystemTools.sln
@@ -1,13 +1,29 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31330.15
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31306.274
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectSystemTools", "src\ProjectSystemTools\ProjectSystemTools.csproj", "{4ADB9F32-E622-4EAA-8DF8-C6D9298FE0EB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogProviders", "src\LogProviders\LogProviders.csproj", "{14674C3A-71F4-4804-81D9-78B95DED8A93}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogModel", "src\LogModel\LogModel.csproj", "{13C36B51-3D0A-497F-B13F-0E7F1947E024}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{42ECF9E1-DF1F-4FBD-A50C-988D44C960B1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		build.cmd = build.cmd
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+		global.json = global.json
+		LICENSE.md = LICENSE.md
+		NuGet.config = NuGet.config
+		README.md = README.md
+		SECURITY.md = SECURITY.md
+		test.cmd = test.cmd
+		eng\Versions.props = eng\Versions.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ProjectSystemTools.sln
+++ b/ProjectSystemTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26913.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31330.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectSystemTools", "src\ProjectSystemTools\ProjectSystemTools.csproj", "{4ADB9F32-E622-4EAA-8DF8-C6D9298FE0EB}"
 EndProject

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!-- Search for public MS packages at https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-public%40Local -->
+  
   <PropertyGroup>
     <VersionPrefix>1.0.1</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
@@ -9,25 +12,24 @@
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <!-- MSBuild -->
-    <MicrosoftBuildVersion>15.6.85</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>16.8.0</MicrosoftBuildVersion>
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.0.0</MicrosoftVisualStudioLanguageServicesVersion>
     <!-- VS SDK -->
-    <MicrosoftVisualStudioComponentModelHostVersion>15.4.27004</MicrosoftVisualStudioComponentModelHostVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>15.4.27004</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioImageCatalogVersion>15.4.27004</MicrosoftVisualStudioImageCatalogVersion>
-    <MicrosoftVisualStudioEditorVersion>15.4.27004</MicrosoftVisualStudioEditorVersion>
-    <MicrosoftVisualStudioProjectSystemSDKVersion>15.3.224</MicrosoftVisualStudioProjectSystemSDKVersion>
-    <MicrosoftVisualStudioShell150Version>15.4.27004</MicrosoftVisualStudioShell150Version>
-    <MicrosoftVisualStudioShellFrameworkVersion>15.4.27004</MicrosoftVisualStudioShellFrameworkVersion>
-    <MicrosoftVisualStudioShellInterop140DesignTimeVersion>15.0.25726-Preview5</MicrosoftVisualStudioShellInterop140DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop150DesignTimeVersion>15.0.26932</MicrosoftVisualStudioShellInterop150DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop153DesignTimeVersion>15.0.26929</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
-    <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop100Version>
-    <MicrosoftVisualStudioUtilitiesVersion>15.4.27004</MicrosoftVisualStudioUtilitiesVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>17.0.67-g9e37b637e6</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioCoreUtilityVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVisualStudioEditorVersion>17.0.30-g62d2639511</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioImageCatalogVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioImageCatalogVersion>
+    <MicrosoftVisualStudioInteropVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioInteropVersion>
+    <MicrosoftVisualStudioInteropVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioInteropVersion>
+    <MicrosoftVisualStudioProjectSystemSDKVersion>17.0.596-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioShell150Version>17.0.0-previews-1-31321-016</MicrosoftVisualStudioShell150Version>
+    <MicrosoftVisualStudioShellFrameworkVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioUtilitiesVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioUtilitiesVersion>
+    <MicrosoftVisualStudioValidationVersion>17.0.11-alpha</MicrosoftVisualStudioValidationVersion>
     <!-- Libs -->
-    <SystemCompositionVersion>1.1.0</SystemCompositionVersion>
+    <SystemCompositionVersion>5.0.1</SystemCompositionVersion>
+    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,6 @@
     <MicrosoftVisualStudioEditorVersion>17.0.30-g62d2639511</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioImageCatalogVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioInteropVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioInteropVersion>
-    <MicrosoftVisualStudioInteropVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVisualStudioProjectSystemSDKVersion>17.0.596-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
     <MicrosoftVisualStudioShell150Version>17.0.0-previews-1-31321-016</MicrosoftVisualStudioShell150Version>
     <MicrosoftVisualStudioShellFrameworkVersion>17.0.0-previews-1-31321-016</MicrosoftVisualStudioShellFrameworkVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,16 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
+
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
+
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -15,7 +15,8 @@ pr:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    name: NetCorePublic-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2019.Open
   variables:
     _os: Windows
   strategy:

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "tools": {
     "vs": {
-      "version": "16.0"
+      "version": "16.8"
     },
-    "xcopy-msbuild": "16.5.0-alpha"
+    "xcopy-msbuild": "16.8.0-preview2.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21314.1"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,4 +13,5 @@
     <!-- Workaround: https://github.com/dotnet/sdk/issues/12739 -->
     <ImportFrameworkWinFXTargets>true</ImportFrameworkWinFXTargets>
   </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,10 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- TODO remove this once we update Arcade to a newer version -->
+  <ItemGroup>
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.0.1056-Dev17PIAs-g9dffd635" />
+  </ItemGroup>
+
 </Project>

--- a/src/LogModel/LogModel.csproj
+++ b/src/LogModel/LogModel.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LogModel/LogModel.csproj
+++ b/src/LogModel/LogModel.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>Microsoft.VisualStudio.ProjectSystem.LogModel</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.ProjectSystem.LogModel</AssemblyName>
     <IsProductComponent>false</IsProductComponent>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LogProviders/LogProviders.csproj
+++ b/src/LogProviders/LogProviders.csproj
@@ -15,18 +15,14 @@
     <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop140DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop150DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/LogProviders/LogProviders.csproj
+++ b/src/LogProviders/LogProviders.csproj
@@ -6,10 +6,6 @@
     <IsProductComponent>false</IsProductComponent>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
     [Guid(ProjectSystemToolsPackage.BinaryLogEditorFactoryGuidString)]
     public sealed class BinaryLogEditorFactory : IVsEditorFactory
     {
-        private static readonly Guid LogicalViewIdAnyGuid = new Guid(LogicalViewID.Any);
-        private static readonly Guid LogicalViewIdPrimaryGuid = new Guid(LogicalViewID.Primary);
-        private static readonly Guid LogicalViewIdDesignerGuid = new Guid(LogicalViewID.Designer);
+        private static readonly Guid LogicalViewIdAnyGuid = new(LogicalViewID.Any);
+        private static readonly Guid LogicalViewIdPrimaryGuid = new(LogicalViewID.Primary);
+        private static readonly Guid LogicalViewIdDesignerGuid = new(LogicalViewID.Designer);
 
         private OLE.Interop.IServiceProvider _site;
         private ServiceProvider _serviceProvider;

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
@@ -19,11 +19,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
     internal sealed class BinaryLogEditorPane : WindowPane, IOleCommandTarget
     {
         private readonly SelectionContainer _selectionContainer;
-        private readonly ObservableCollection<BaseViewModel> _buildTreeViewItems = new ObservableCollection<BaseViewModel>();
-        private readonly ObservableCollection<BaseViewModel> _evaluationTreeViewItems = new ObservableCollection<BaseViewModel>();
-        private readonly ObservableCollection<TargetListViewModel> _targetListViewItems = new ObservableCollection<TargetListViewModel>();
-        private readonly ObservableCollection<TaskListViewModel> _taskListViewItems = new ObservableCollection<TaskListViewModel>();
-        private readonly ObservableCollection<EvaluationListViewModel> _evaluationListViewItems = new ObservableCollection<EvaluationListViewModel>();
+        private readonly ObservableCollection<BaseViewModel> _buildTreeViewItems = new();
+        private readonly ObservableCollection<BaseViewModel> _evaluationTreeViewItems = new();
+        private readonly ObservableCollection<TargetListViewModel> _targetListViewItems = new();
+        private readonly ObservableCollection<TaskListViewModel> _taskListViewItems = new();
+        private readonly ObservableCollection<EvaluationListViewModel> _evaluationListViewItems = new();
         private readonly BinaryLogDocumentData _documentData;
 
         public BinaryLogEditorPane(BinaryLogDocumentData documentData)
@@ -178,7 +178,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
                 shell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, ref propertyBrowser, out var frame);
                 frame?.ShowNoActivate();
             }
-
         }
     }
 }

--- a/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
         // _entries.Item1 == all entries from the last entries changed event;
         // _entries.Item2 == the filtered entries from the same event.
         // Save this as a tuple so that, if accessed from another thread, the tuple gives a consistent snapshot.
-        private Tuple<IReadOnlyCollection<ITableEntryHandle>, IReadOnlyCollection<ITableEntryHandle>> _entries = new Tuple<IReadOnlyCollection<ITableEntryHandle>, IReadOnlyCollection<ITableEntryHandle>>(new ITableEntryHandle[0], new ITableEntryHandle[0]);
+        private Tuple<IReadOnlyCollection<ITableEntryHandle>, IReadOnlyCollection<ITableEntryHandle>> _entries = new(new ITableEntryHandle[0], new ITableEntryHandle[0]);
 
         private IReadOnlyList<ColumnState> _columnStates;
 

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessorProvider.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessorProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 {
     [Export(typeof(ITableControlEventProcessorProvider))]
     [Name(BuildLog)]
-    [Utilities.Order(After = Priority.Default, Before = StandardTableControlEventProcessors.Default)]
+    [VisualStudio.Utilities.Order(After = Priority.Default, Before = StandardTableControlEventProcessors.Default)]
     [ManagerType(BuildLoggingToolWindow.BuildLogging)]
     [DataSourceType(StandardTableDataSources.AnyDataSource)]
     [DataSource(StandardTableDataSources.AnyDataSource)]

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -65,6 +65,8 @@
       <ManifestResourceName>VSPackage</ManifestResourceName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\LogModel\LogModel.csproj">
       <Name>LogModel</Name>
       <Private>true</Private>
@@ -73,6 +75,8 @@
       <Name>LogProviders</Name>
       <Private>true</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <VSCTCompile Include="ProjectSystemToolsPackage.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -25,21 +25,15 @@
     <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop140DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop150DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
-    <PackageReference Include="VSLangProj" Version="7.0.3301" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="17.0.0-preview-1-31216-036" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
@@ -51,6 +45,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="xlf\*" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="BinaryLogEditor\BinaryLogEditorResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>BinaryLogEditorResources.Designer.cs</LastGenOutput>

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -15,7 +15,7 @@
     <!-- Disable warnings if there is a mismach of Embed Interop types. The Roslyn packages references some shell
          binaries without it, but Microsoft.VisualStudio.SDK.EmbedInteropTypes turns it on. Silencing the warning will
          mean we won't embed the things already not being embedded, but that's harmless. -->
-    <NoWarn>1762</NoWarn>
+    <NoWarn>$(NoWarn);1762</NoWarn>
 
     <!-- Work around dotnet/wpf#1718 for the time being -->
     <EmbedUntrackedSources>false</EmbedUntrackedSources>

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 using System.ComponentModel.Design;
+using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor;
@@ -150,6 +151,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
             ThreadHelper.ThrowIfNotOnUIThread();
 
             RoslynLogging.RoslynWorkspaceStructureLogger.ShowSaveDialogAndLog(ServiceProvider);
+        }
+
+        public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (toolWindowType == typeof(MessageListToolWindow).GUID ||
+                toolWindowType == typeof(BuildLoggingToolWindow).GUID)
+            {
+                return this;
+            }
+
+            return base.GetAsyncToolWindowFactory(toolWindowType);
+        }
+
+        protected override string GetToolWindowTitle(Type toolWindowType, int id)
+        {
+            if (toolWindowType == typeof(MessageListToolWindow))
+            {
+                return BinaryLogEditorResources.MessageListWindowTitle;
+            }
+
+            if (toolWindowType == typeof(BuildLoggingToolWindow))
+            {
+                return BuildLoggingResources.BuildLogWindowTitle;
+            }
+
+            return base.GetToolWindowTitle(toolWindowType, id);
+        }
+
+        protected override Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<object>(null);
         }
     }
 }

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -151,6 +151,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
             RoslynLogging.RoslynWorkspaceStructureLogger.ShowSaveDialogAndLog(ServiceProvider);
         }
-
     }
 }

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             });
         }
 
-        // Default to the bottom-left corner of the control for the position of contect menu invoked from keyboard
+        // Default to the bottom-left corner of the control for the position of context menu invoked from keyboard
         private Point GetKeyboardContextMenuAnchorPoint() => PointToScreen(new Point(0, RenderSize.Height));
 
         // Get the current mouse position and convert it to screen coordinates as the shell expects a screen position

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="B6213233-1C34-4F76-9DD5-F6D520C32AA3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="cb5b6a78-6fa1-4830-a272-760862eb77af" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Project System Tools 2022</DisplayName>
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
     <Icon>Icon.png</Icon>

--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -2,20 +2,22 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="B6213233-1C34-4F76-9DD5-F6D520C32AA3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Project System Tools</DisplayName>
+    <DisplayName>Project System Tools 2022</DisplayName>
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
     <Icon>Icon.png</Icon>
     <PreviewImage>Icon.png</PreviewImage>
     <Tags>project, csproj, vbproj</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Fixes #398.

This PR upgrades the Project System Tools extension for Visual Studio so it will work in the forthcoming major release, VS2022.

There are considerable changes to the extensibility model for Dev17, and this new code means the extension will no longer be compatible with earlier version of VS. I anticipate we will want to fork the VSIX package on the marketplace. I'm unclear on the best way to do this. cc @madskristensen

