### PR TITLE
Fix diagnostics produced by updated assemblies

### DIFF
--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogDocumentData.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogDocumentData.cs
@@ -90,9 +90,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         public int SetDocDataReadOnly(int isReadOnly) => VSConstants.S_OK;
 
-        int IPersist.GetClassID(out Guid classId) => GetGuidEditorType(out classId);
+        int IPersist.GetClassID(out Guid classId)
+        {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread();
+            return GetGuidEditorType(out classId);
+        }
 
-        public int IsDirty(out int isDirty) => IsDocDataDirty(out isDirty);
+        public int IsDirty(out int isDirty)
+        {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread();
+            return IsDocDataDirty(out isDirty);
+        }
 
         public int InitNew(uint formatIndex) => VSConstants.S_OK;
 
@@ -118,6 +126,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
             return VSConstants.S_OK;
         }
 
-        int IPersistFileFormat.GetClassID(out Guid classId) => GetGuidEditorType(out classId);
+        int IPersistFileFormat.GetClassID(out Guid classId)
+        {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread();
+            return GetGuidEditorType(out classId);
+        }
     }
 }

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
@@ -64,6 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         int IVsEditorFactory.Close()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_serviceProvider != null)
             {
                 _serviceProvider.Dispose();

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
@@ -111,6 +111,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         private void SelectionChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (!(GetService(typeof(STrackSelection)) is ITrackSelection track))
             {
                 return;
@@ -142,6 +144,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         private void GridSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            
             if (!(GetService(typeof(STrackSelection)) is ITrackSelection track))
             {
                 return;

--- a/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
@@ -82,6 +82,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         public MessageListToolWindow()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             UpdateLabels(0, 0, 0, 0, 0, 0);
 
             var defaultColumns = new List<ColumnState>
@@ -135,6 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         protected override void Dispose(bool disposing)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (IsDisposed)
             {
                 return;
@@ -156,6 +160,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         protected override void Initialize()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             _monitorSelection?.AdviseSelectionEvents(this, out _eventsCookie);
         }
 
@@ -213,6 +219,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         private void UpdateLabels(int totalErrors, int visibleErrors, int totalWarnings, int visibleWarnings, int totalMessages, int visibleMessages)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var newErrorsLabel = string.Format(CultureInfo.InvariantCulture,
                                                   totalErrors == visibleErrors ? BinaryLogEditorResources.SameLabel : BinaryLogEditorResources.DifferentLabel,
                                                   totalErrors == 1 ? BinaryLogEditorResources.ErrorLabel : BinaryLogEditorResources.ErrorsLabel, visibleErrors, totalErrors);
@@ -241,6 +249,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 
         private void OnEntriesChanged(object sender, EntriesChangedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (ProjectSystemToolsPackage.IsDisposed)
             {
                 return;
@@ -598,6 +608,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
         public int OnSelectionChanged(IVsHierarchy oldHierarchy, uint oldItemid, IVsMultiItemSelect oldItemSelect, ISelectionContainer oldSelectionContainer,
             IVsHierarchy pHierNew, uint newItemid, IVsMultiItemSelect newItemSelect, ISelectionContainer newSelectionContainer)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (newSelectionContainer == null)
             {
                 return VSConstants.S_OK;

--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -43,6 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         public BuildLoggingToolWindow()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var componentModel = (IComponentModel)GetService(typeof(SComponentModel));
             _dataSource = componentModel.GetService<IFrontEndBuildTableDataSource>();
 
@@ -92,6 +94,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         protected override void Initialize()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             base.Initialize();
 
             // When we are activated, we push our command target as the current Result List so that
@@ -117,6 +121,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         private void OnFiltersChanged(object sender, FiltersChangedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (e.Key == TableColumnNames.BuildType && e.NewFilter is ColumnHashSetFilter filter)
             {
                 switch (filter.ExcludedCount)
@@ -148,8 +154,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
             ProjectSystemToolsPackage.UpdateQueryStatus();
         }
 
-        private static void OnGroupingsChanged(object sender, EventArgs e) =>
+        private static void OnGroupingsChanged(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             ProjectSystemToolsPackage.UpdateQueryStatus();
+        }
 
         protected override void SetTableControl(IWpfTableControl2 tableControl)
         {
@@ -242,6 +252,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         private void OpenLogs()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             foreach (var entry in TableControl.SelectedEntries)
             {
                 OpenLog(entry);
@@ -250,6 +262,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         public void OpenLog(ITableEntryHandle tableEntry)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (!tableEntry.TryGetValue(TableKeyNames.BuildID, out int buildID))
             {
                 return;
@@ -258,6 +272,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
             var guid = VSConstants.LOGVIEWID_Primary;
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 string logPath = await _dataSource.GetLogForBuildAsync(buildID);
                 _openDocument.OpenDocumentViaProject(logPath, ref guid, out _, out _, out _, out var frame);
                 frame?.Show();
@@ -386,6 +402,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging
 
         protected override int InnerExec(ref Guid commandGroupGuid, uint commandId, uint commandExecOption, IntPtr pvaIn, IntPtr pvaOut)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (commandGroupGuid != ProjectSystemToolsPackage.CommandSetGuid)
             {
                 return (int)Constants.OLECMDERR_E_NOTSUPPORTED;

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessor.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.TableControl;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
@@ -13,10 +14,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
             _toolWindow = toolWindow;
         }
 
-        public override void PostprocessNavigate(ITableEntryHandle entryHandle, TableEntryNavigateEventArgs e) => _toolWindow.OpenLog(entryHandle);
+        public override void PostprocessNavigate(ITableEntryHandle entryHandle, TableEntryNavigateEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            _toolWindow.OpenLog(entryHandle);
+        }
 
         public override void PreprocessSelectionChanged(TableSelectionChangedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             ProjectSystemToolsPackage.UpdateQueryStatus();
 
             base.PreprocessSelectionChanged(e);

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -115,6 +115,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
         public static void UpdateQueryStatus()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Force the shell to refresh the QueryStatus for all the command since some of them may have been flagged as
             // not supported (because the host had focus but the view did not) and switching focus from the zoom control
             // back to the view will not automatically force the shell to requery for the command status.
@@ -123,12 +125,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
         private void ShowBuildLoggingToolWindow(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var windowFrame = (IVsWindowFrame)BuildLoggingToolWindow.Frame;
             ErrorHandler.ThrowOnFailure(windowFrame.Show());
         }
 
         private void ShowMessageListToolWindow(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var window = FindToolWindow(typeof(MessageListToolWindow), 0, true);
             if (window?.Frame == null)
             {
@@ -141,6 +147,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
         private void LogRoslynWorkspaceStructure(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             RoslynLogging.RoslynWorkspaceStructureLogger.ShowSaveDialogAndLog(ServiceProvider);
         }
 

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -86,14 +86,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
             PackageTaskCollection = ThreadHelper.JoinableTaskContext.CreateCollection();
             PackageTaskFactory = ThreadHelper.JoinableTaskContext.CreateFactory(PackageTaskCollection);
 
-            VsUIShell = GetService(typeof(IVsUIShell)) as IVsUIShell;
-            VsFindManager = GetService(typeof(SVsFindManager)) as IVsFindManager;
+            VsUIShell = await GetServiceAsync(typeof(IVsUIShell)) as IVsUIShell;
+            VsFindManager = await GetServiceAsync(typeof(SVsFindManager)) as IVsFindManager;
 
-            var componentModel = GetService(typeof(SComponentModel)) as IComponentModel;
+            var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
             TableControlProvider = componentModel?.GetService<IWpfTableControlProvider>();
             TableManagerProvider = componentModel?.GetService<ITableManagerProvider>();
 
-            var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            var mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
             mcs?.AddCommand(new MenuCommand(ShowBuildLoggingToolWindow, new CommandID(CommandSetGuid, BuildLoggingCommandId)));
             mcs?.AddCommand(new MenuCommand(ShowMessageListToolWindow, new CommandID(CommandSetGuid, MessageListCommandId)));
             mcs?.AddCommand(new MenuCommand(LogRoslynWorkspaceStructure, new CommandID(CommandSetGuid, LogRoslynWorkspaceStructureCommandId)));

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
@@ -19,14 +20,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             _contextMenuId = contextMenuId;
         }
 
-        protected override void OnPreviewMouseRightButtonUp(MouseButtonEventArgs e) => OpenContextMenu();
+        protected override void OnPreviewMouseRightButtonUp(MouseButtonEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
 
-        internal static bool PreProcessMessage(ref Message m, IOleCommandTarget cmdTarget) =>
-            m.Msg == 0x007B &&
-            ErrorHandler.Succeeded(cmdTarget.Exec(VSConstants.VSStd2K, (uint)VSConstants.VSStd2KCmdID.SHOWCONTEXTMENU, 0, IntPtr.Zero, IntPtr.Zero));
+            OpenContextMenu();
+        }
+
+        internal static bool PreProcessMessage(ref Message m, IOleCommandTarget cmdTarget)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return m.Msg == 0x007B &&
+                   ErrorHandler.Succeeded(cmdTarget.Exec(VSConstants.VSStd2K, (uint)VSConstants.VSStd2KCmdID.SHOWCONTEXTMENU, 0, IntPtr.Zero, IntPtr.Zero));
+        }
 
         internal void OpenContextMenu()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_contextMenuId == -1)
             {
                 return;

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -50,9 +50,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
             // Show context menu blocks, so we need to yield out of this method
             // for e.Handled to be noticed by WPF
-            Dispatcher.BeginInvoke(new Action(() =>
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 ProjectSystemToolsPackage.VsUIShell.ShowContextMenu(0, ref guidContextMenu, _contextMenuId,
-                    locationPoints, pCmdTrgtActive: null)));
+                    locationPoints, pCmdTrgtActive: null);
+            });
         }
 
         // Default to the bottom-left corner of the control for the position of contect menu invoked from keyboard

--- a/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 
@@ -28,6 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public bool Match(ITableEntryHandle entry)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var cachedColumnValues = new string[_visibleColumns.Count + 1];
 
             return _searchTokens.Where(searchToken => !(searchToken is IVsSearchFilterToken))
@@ -37,6 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         private bool AtLeastOneColumnOrDetailsContentMatches(ITableEntryHandle entry, IVsSearchToken searchToken, string[] cachedColumnValues)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (cachedColumnValues[0] == null)
             {
                 cachedColumnValues[0] = GetDetailsContentAsString(entry);
@@ -85,8 +90,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             return detailsString ?? string.Empty;
         }
 
-        private static bool Match(string columnValue, IVsSearchToken searchToken) =>
-            columnValue != null && columnValue.IndexOf(searchToken.ParsedTokenText,
-                StringComparison.OrdinalIgnoreCase) >= 0;
+        private static bool Match(string columnValue, IVsSearchToken searchToken)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return
+                columnValue != null &&
+                columnValue.IndexOf(searchToken.ParsedTokenText, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
     }
 }

--- a/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
@@ -33,9 +33,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
             var cachedColumnValues = new string[_visibleColumns.Count + 1];
 
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             return _searchTokens.Where(searchToken => !(searchToken is IVsSearchFilterToken))
                 .All(searchToken => AtLeastOneColumnOrDetailsContentMatches(entry, searchToken,
                     cachedColumnValues));
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         }
 
         private bool AtLeastOneColumnOrDetailsContentMatches(ITableEntryHandle entry, IVsSearchToken searchToken, string[] cachedColumnValues)

--- a/src/ProjectSystemTools/TableControl/TableToolWindow.cs
+++ b/src/ProjectSystemTools/TableControl/TableToolWindow.cs
@@ -43,11 +43,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             Content = _contentWrapper;
         }
 
-        private static void OnFiltersChanged(object sender, FiltersChangedEventArgs e) =>
-            ProjectSystemToolsPackage.UpdateQueryStatus();
+        private static void OnFiltersChanged(object sender, FiltersChangedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
 
-        private static void OnGroupingsChanged(object sender, EventArgs e) =>
             ProjectSystemToolsPackage.UpdateQueryStatus();
+        }
+
+        private static void OnGroupingsChanged(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ProjectSystemToolsPackage.UpdateQueryStatus();
+        }
 
         protected virtual void SetTableControl(IWpfTableControl2 tableControl)
         {
@@ -118,6 +126,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         int IOleCommandTarget.QueryStatus(ref Guid commandGroupGuid, uint commandCount, OLECMD[] commands, IntPtr commandText)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var result = InnerQueryStatus(ref commandGroupGuid, commandCount, commands, commandText);
 
             if (result == VSConstants.S_OK)
@@ -130,6 +140,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         int IOleCommandTarget.Exec(ref Guid commandGroupGuid, uint commandId, uint commandExecOption, IntPtr pvaIn, IntPtr pvaOut)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var result = InnerExec(ref commandGroupGuid, commandId, commandExecOption, pvaIn, pvaOut);
 
             if (result == VSConstants.S_OK)
@@ -149,8 +161,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
             return ((IOleCommandTarget)TableControl).Exec(ref commandGroupGuid, commandId, commandExecOption, pvaIn, pvaOut);
         }
 
-        protected override bool PreProcessMessage(ref Message m) =>
-            ContentWrapper.PreProcessMessage(ref m, this) || base.PreProcessMessage(ref m);
+        protected override bool PreProcessMessage(ref Message m)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return ContentWrapper.PreProcessMessage(ref m, this) || base.PreProcessMessage(ref m);
+        }
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
#386 is an automated PR that upgrades the version of Arcade used by this repo. It is currently failing due to warnings I also hit when authoring #392.

This PR pulls out those fixes from yesterday's PR into their own PR with the goal of unblocking the automated Arcade upgrade.

It is possible that having a newer version of Arcade will also help in getting the VS2022 PR merged too.