### PR TITLE
Limit package to VS 2017 and 2019

### DIFF
--- a/src/ProjectSystemTools/source.extension.vsixmanifest
+++ b/src/ProjectSystemTools/source.extension.vsixmanifest
@@ -2,14 +2,14 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="B6213233-1C34-4F76-9DD5-F6D520C32AA3" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Project System Tools</DisplayName>
+    <DisplayName>Project System Tools 2017/2019</DisplayName>
     <Description>Tools for working with the C#, Visual Basic, and F# project systems.</Description>
     <Icon>Icon.png</Icon>
     <PreviewImage>Icon.png</PreviewImage>
     <Tags>project, csproj, vbproj</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0.27004.2002,17.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Previously, the supported version range was unbounded. This meant the package would advertise itself as supporting VS2022. Due to the significant changes in VS2022 this version of the package does not work in VS2022. We will create a release branch and have separate packages for VS2017/2019 and VS2022.

This commit is part of that change.