### PR TITLE
Fix design-time build name and viewer

### DIFF
--- a/src/LogModel/Builder/ModelBuilder.cs
+++ b/src/LogModel/Builder/ModelBuilder.cs
@@ -231,8 +231,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel.Builder
         private static void CheckProjectEventContext(BuildEventArgs args)
         {
             if (args.BuildEventContext.TargetId != -1 ||
-                args.BuildEventContext.TaskId != -1 ||
-                args.BuildEventContext.EvaluationId != -1)
+                args.BuildEventContext.TaskId != -1)
             {
                 throw new LoggerException(Resources.BadState);
             }
@@ -252,8 +251,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel.Builder
             CheckProjectEventContext(args);
 
             if (args.ParentProjectBuildEventContext.TargetId != -1 ||
-                args.ParentProjectBuildEventContext.TaskId != -1 ||
-                args.ParentProjectBuildEventContext.EvaluationId != -1)
+                args.ParentProjectBuildEventContext.TaskId != -1)
             {
                 throw new LoggerException(Resources.BadState);
             }
@@ -771,7 +769,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel.Builder
 
             if (args.BuildEventContext != null)
             {
-                if (args.BuildEventContext.EvaluationId != BuildEventContext.InvalidEvaluationId)
+                if (args.BuildEventContext.EvaluationId != BuildEventContext.InvalidEvaluationId &&
+                    args.BuildEventContext.ProjectContextId == BuildEventContext.InvalidProjectContextId)
                 {
                     ProcessEvaluationMessage(args);
                     return;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
     internal sealed class Build : IDisposable
     {
         public BuildSummary BuildSummary { get; private set; }
-        public string ProjectPath { get; }
+        public string ProjectPath { get; private set; }
         public string LogPath { get; private set; }
         public int BuildId => BuildSummary.BuildId;
         public BuildType BuildType => BuildSummary.BuildType;
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
         public Build(string projectPath, IEnumerable<string> dimensions, IEnumerable<string> targets, BuildType buildType, DateTime startTime)
         {
             int nextId = Interlocked.Increment(ref SharedBuildId);
+            ProjectPath = projectPath;
             BuildSummary = new BuildSummary(nextId, projectPath, dimensions, targets, buildType, startTime);
         }
 


### PR DESCRIPTION
The project path property wasn't being set on build objects, so the saved design-time build files lacked the project name. Also, there were [changes](https://github.com/dotnet/msbuild/pull/6287) in MSBuild that broke the binlog viewer.