### PR TITLE
Fix up binlog viewer

### DIFF
--- a/src/LogModel/Builder/ProjectInfo.cs
+++ b/src/LogModel/Builder/ProjectInfo.cs
@@ -16,6 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel.Builder
         public int NodeId { get; }
         public string Name { get; }
         public int ParentProject { get; }
+        public int ParentTarget { get; }
+        public int ParentTask { get; }
         public DateTime StartTime { get; }
         public DateTime EndTime { get; private set; }
         public string ProjectFile { get; }
@@ -27,11 +29,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel.Builder
         public ImmutableHashSet<string> TargetsToBuild { get; }
         public string ToolsVersion { get; }
 
-        public ProjectInfo(int id, int nodeId, int parentProject, DateTime startTime, ImmutableHashSet<string> targetsToBuild, string toolsVersion, string name, string projectFile, ImmutableDictionary<string, string> globalProperties, ImmutableDictionary<string, string> properties, ImmutableList<ItemGroupInfo> itemGroups)
+        public ProjectInfo(int id, int nodeId, int parentProject, int parentTarget, int parentTask, DateTime startTime, ImmutableHashSet<string> targetsToBuild, string toolsVersion, string name, string projectFile, ImmutableDictionary<string, string> globalProperties, ImmutableDictionary<string, string> properties, ImmutableList<ItemGroupInfo> itemGroups)
         {
             Id = id;
             NodeId = nodeId;
             ParentProject = parentProject;
+            ParentTarget = parentTarget;
+            ParentTask = parentTask;
             StartTime = startTime;
             TargetsToBuild = targetsToBuild;
             ToolsVersion = toolsVersion;

--- a/src/LogModel/Resources.Designer.cs
+++ b/src/LogModel/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -165,6 +165,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.LogModel {
         internal static string ExpectedItemGroupName {
             get {
                 return ResourceManager.GetString("ExpectedItemGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected item name..
+        /// </summary>
+        internal static string ExpectedItemName {
+            get {
+                return ResourceManager.GetString("ExpectedItemName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected metadata..
+        /// </summary>
+        internal static string ExpectedMetadata {
+            get {
+                return ResourceManager.GetString("ExpectedMetadata", resourceCulture);
             }
         }
         

--- a/src/LogModel/Resources.resx
+++ b/src/LogModel/Resources.resx
@@ -153,6 +153,12 @@
   <data name="ExpectedItemGroupName" xml:space="preserve">
     <value>Expected item group name.</value>
   </data>
+  <data name="ExpectedItemName" xml:space="preserve">
+    <value>Expected item name.</value>
+  </data>
+  <data name="ExpectedMetadata" xml:space="preserve">
+    <value>Expected metadata.</value>
+  </data>
   <data name="OverwritingMetadata" xml:space="preserve">
     <value>Overwriting metadata.</value>
   </data>

--- a/src/LogModel/xlf/Resources.cs.xlf
+++ b/src/LogModel/xlf/Resources.cs.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.de.xlf
+++ b/src/LogModel/xlf/Resources.de.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.es.xlf
+++ b/src/LogModel/xlf/Resources.es.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.fr.xlf
+++ b/src/LogModel/xlf/Resources.fr.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.it.xlf
+++ b/src/LogModel/xlf/Resources.it.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.ja.xlf
+++ b/src/LogModel/xlf/Resources.ja.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.ko.xlf
+++ b/src/LogModel/xlf/Resources.ko.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.pl.xlf
+++ b/src/LogModel/xlf/Resources.pl.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.pt-BR.xlf
+++ b/src/LogModel/xlf/Resources.pt-BR.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.ru.xlf
+++ b/src/LogModel/xlf/Resources.ru.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.tr.xlf
+++ b/src/LogModel/xlf/Resources.tr.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.zh-Hans.xlf
+++ b/src/LogModel/xlf/Resources.zh-Hans.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>

--- a/src/LogModel/xlf/Resources.zh-Hant.xlf
+++ b/src/LogModel/xlf/Resources.zh-Hant.xlf
@@ -62,6 +62,16 @@
         <target state="new">Expected item group name.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpectedItemName">
+        <source>Expected item name.</source>
+        <target state="new">Expected item name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpectedMetadata">
+        <source>Expected metadata.</source>
+        <target state="new">Expected metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OverwritingMetadata">
         <source>Overwriting metadata.</source>
         <target state="new">Overwriting metadata.</target>


### PR DESCRIPTION
This fixes two issues with the binlog viewer:

- @KirillOsenkov added links between project builds and parent MSBuild tasks, so it takes advantage of that.
- The message parsing code was a bit wonky and could get lost with certain kinds of messages.