### PR TITLE
Use MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,23 @@
-Copyright (c) .NET Foundation and Contributors
+The MIT License (MIT)
+
+Copyright (c) Microsoft.
 
 All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the “License”); you may not
-use this file except in compliance with the License. You may obtain a copy of
-the License at
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    http://www.apache.org/licenses/LICENSE-2.0
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations under
-the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,4 @@
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 

--- a/src/LogModel/Build.cs
+++ b/src/LogModel/Build.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/BaseInfo.cs
+++ b/src/LogModel/Builder/BaseInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/LogModel/Builder/BuildInfo.cs
+++ b/src/LogModel/Builder/BuildInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/DiagnosticInfo.cs
+++ b/src/LogModel/Builder/DiagnosticInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Builder/EvaluatedLocationInfo.cs
+++ b/src/LogModel/Builder/EvaluatedLocationInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/EvaluatedPassInfo.cs
+++ b/src/LogModel/Builder/EvaluatedPassInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/EvaluatedProfileInfo.cs
+++ b/src/LogModel/Builder/EvaluatedProfileInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/EvaluatedProjectInfo.cs
+++ b/src/LogModel/Builder/EvaluatedProjectInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Builder/EvaluationInfo.cs
+++ b/src/LogModel/Builder/EvaluationInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LogModel/Builder/ItemActionInfo.cs
+++ b/src/LogModel/Builder/ItemActionInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Builder/ItemGroupInfo.cs
+++ b/src/LogModel/Builder/ItemGroupInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LogModel/Builder/ItemInfo.cs
+++ b/src/LogModel/Builder/ItemInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LogModel/Builder/MessageInfo.cs
+++ b/src/LogModel/Builder/MessageInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Builder/ModelBuilder.cs
+++ b/src/LogModel/Builder/ModelBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/LogModel/Builder/ProjectInfo.cs
+++ b/src/LogModel/Builder/ProjectInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/LogModel/Builder/PropertySetInfo.cs
+++ b/src/LogModel/Builder/PropertySetInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Builder/TargetInfo.cs
+++ b/src/LogModel/Builder/TargetInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/LogModel/Builder/TaskInfo.cs
+++ b/src/LogModel/Builder/TaskInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/LogModel/Builder/TimeInfo.cs
+++ b/src/LogModel/Builder/TimeInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Diagnostic.cs
+++ b/src/LogModel/Diagnostic.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/EvaluatedLocation.cs
+++ b/src/LogModel/EvaluatedLocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/LogModel/EvaluatedPass.cs
+++ b/src/LogModel/EvaluatedPass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 using Microsoft.Build.Framework.Profiler;

--- a/src/LogModel/EvaluatedProfile.cs
+++ b/src/LogModel/EvaluatedProfile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LogModel/EvaluatedProject.cs
+++ b/src/LogModel/EvaluatedProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Evaluation.cs
+++ b/src/LogModel/Evaluation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LogModel/Item.cs
+++ b/src/LogModel/Item.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LogModel/ItemAction.cs
+++ b/src/LogModel/ItemAction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/ItemGroup.cs
+++ b/src/LogModel/ItemGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LogModel/Log.cs
+++ b/src/LogModel/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/LogModel.csproj.DotSettings
+++ b/src/LogModel/LogModel.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp71</s:String></wpf:ResourceDictionary>

--- a/src/LogModel/Message.cs
+++ b/src/LogModel/Message.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LogModel
 {

--- a/src/LogModel/Node.cs
+++ b/src/LogModel/Node.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Project.cs
+++ b/src/LogModel/Project.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/PropertySet.cs
+++ b/src/LogModel/PropertySet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogModel/Result.cs
+++ b/src/LogModel/Result.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.LogModel
 {

--- a/src/LogModel/Target.cs
+++ b/src/LogModel/Target.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Task.cs
+++ b/src/LogModel/Task.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/LogModel/Time.cs
+++ b/src/LogModel/Time.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/LogProviders/BuildLoggerProvider.cs
+++ b/src/LogProviders/BuildLoggerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/LogProviders/ILoggingController.cs
+++ b/src/LogProviders/ILoggingController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.Build.Framework;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogDocumentData.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogDocumentData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BinaryLogEditorPane.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/BuildTreeViewControl.xaml.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/BuildTreeViewControl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 {

--- a/src/ProjectSystemTools/BinaryLogEditor/EvaluationTreeViewControl.xaml.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/EvaluationTreeViewControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 {

--- a/src/ProjectSystemTools/BinaryLogEditor/LogViewControl.xaml.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/LogViewControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
 {

--- a/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/NodeDataTemplateSelector.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/NodeDataTemplateSelector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Windows;
 using System.Windows.Controls;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/BaseViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/BaseViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/BuildViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/BuildViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/DictionaryBasedPropertyDescriptor.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/DictionaryBasedPropertyDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedLocationViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedLocationViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedPassViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedPassViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedProjectViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluatedProjectViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluationListViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluationListViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluationViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/EvaluationViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ExceptionViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ExceptionViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/IViewModelWithProperties.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/IViewModelWithProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor.ViewModel
 {

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ItemViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ItemViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.ProjectSystem.LogModel;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ListViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ListViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/NodeViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/NodeViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.ProjectSystem.LogModel;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ProjectViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/ProjectViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/PropertyViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/PropertyViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/RootViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/RootViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.ObjectModel;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/SelectedObjectWrapper.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/SelectedObjectWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TargetListViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TargetListViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TargetViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TargetViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TaskListViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TaskListViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TaskViewModel.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/TaskViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/BuildLoggingToolWindow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/BackendBuildTableDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/BackendBuildTableDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/BuildLoggerService.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/BuildLoggerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/ILoggingDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/ILoggingDataSource.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
@@ -17,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
         /// when data on the logging service is updated
         /// </summary>
         /// <param name="notifyCallback">An Action callback that will be used
-        /// whenver new data is logged by the service</param>
+        /// whenever new data is logged by the service</param>
         void Start(Action notifyCallback);
 
         /// <summary>

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/LoggerBase.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/LoggerBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.IO;
 using System.Linq;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/ProjectLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/ProjectLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/RoslynLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/RoslynLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BuildLogging/Model/BuildStatus.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model
 {

--- a/src/ProjectSystemTools/BuildLogging/Model/BuildSummary.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildSummary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/BuildType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 

--- a/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BuildLogging/Model/Frontend/IFrontendBuildTableDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Frontend/IFrontendBuildTableDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.TableManager;

--- a/src/ProjectSystemTools/BuildLogging/Model/Frontend/UIBuildSummary.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Frontend/UIBuildSummary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/ProjectSystemTools/BuildLogging/Model/RpcContracts/IBuildLoggerService.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/RpcContracts/IBuildLoggerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessor.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.TableControl;

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessorProvider.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildLogTableEventProcessorProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell.TableControl;

--- a/src/ProjectSystemTools/BuildLogging/UI/BuildTableEntriesSnapshot.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildTableEntriesSnapshot.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.FrontEnd;

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/ProjectSystemTools/RoslynLogging/RoslynWorkspaceStructureLogger.cs
+++ b/src/ProjectSystemTools/RoslynLogging/RoslynWorkspaceStructureLogger.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;

--- a/src/ProjectSystemTools/TableControl/BuildTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/BuildTypeColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/ProjectSystemTools/TableControl/ContentWrapper.cs
+++ b/src/ProjectSystemTools/TableControl/ContentWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Windows;

--- a/src/ProjectSystemTools/TableControl/DimensionsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/DimensionsColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/ProjectSystemTools/TableControl/ProjectTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ProjectTypeColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/ProjectSystemTools/TableControl/StartTimeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/StartTimeColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/ProjectSystemTools/TableControl/StatusColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/StatusColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/ProjectSystemTools/TableControl/TableColumnNames.cs
+++ b/src/ProjectSystemTools/TableControl/TableColumnNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 {

--- a/src/ProjectSystemTools/TableControl/TableKeyNames.cs
+++ b/src/ProjectSystemTools/TableControl/TableKeyNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 {

--- a/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/TableControl/TableSearchTask.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/ProjectSystemTools/TableControl/TableSettingLoader.cs
+++ b/src/ProjectSystemTools/TableControl/TableSettingLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/TableControl/TableToolWindow.cs
+++ b/src/ProjectSystemTools/TableControl/TableToolWindow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Design;

--- a/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TargetsColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ProjectSystemTools/TableControl/TimeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TimeColumnDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.ComponentModel.Composition;


### PR DESCRIPTION
Fixes #413

This commit changes the repository's license from Apache 2.0 to Apache.