### PR TITLE
Fix broken search function

### DIFF
--- a/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.PlatformUI;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 
@@ -12,6 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 {
     internal class TableSearchFilter : IEntryFilter
     {
+        // NOTE methods on this type are invoked on a worker thread
+
         private readonly IEnumerable<IVsSearchToken> _searchTokens;
         private readonly IReadOnlyList<ITableColumnDefinition> _visibleColumns;
 
@@ -29,8 +30,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public bool Match(ITableEntryHandle entry)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             var cachedColumnValues = new string[_visibleColumns.Count + 1];
 
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
@@ -42,8 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         private bool AtLeastOneColumnOrDetailsContentMatches(ITableEntryHandle entry, IVsSearchToken searchToken, string[] cachedColumnValues)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             if (cachedColumnValues[0] == null)
             {
                 cachedColumnValues[0] = GetDetailsContentAsString(entry);
@@ -94,11 +91,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         private static bool Match(string columnValue, IVsSearchToken searchToken)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             return
                 columnValue != null &&
                 columnValue.IndexOf(searchToken.ParsedTokenText, StringComparison.OrdinalIgnoreCase) >= 0;
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         }
     }
 }

--- a/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
+++ b/src/ProjectSystemTools/TableControl/TableSearchFilter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public TableSearchFilter(IVsSearchQuery searchQuery, IWpfTableControl control)
         {
-            _searchTokens = SearchUtilities.ExtractSearchTokens(searchQuery) ?? new IVsSearchToken[] { };
+            _searchTokens = SearchUtilities.ExtractSearchTokens(searchQuery) ?? Array.Empty<IVsSearchToken>();
 
             var newVisibleColumns = control.ColumnStates
                 .Where(c => c.IsVisible || (c as ColumnState2)?.GroupingPriority > 0)


### PR DESCRIPTION
Fixes #422 

At some point in the history, we updated the vs-threading analyzers which flagged some API usage are requiring the main thread. To suppress those, we added `ThreadHelper.ThrowIfNotOnUIThread()`.

In reality, these search methods are called on a worker thread. This led to an exception, which caused search to fail.

The fix is to remove these checks, suppress the warnings, and document the behaviour.