### PR TITLE
Allow "elapsed" column value to be copied to the clipboard

### DIFF
--- a/src/ProjectSystemTools/TableControl/BuildTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/BuildTypeColumnDefinition.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.BuildType, out var value) && value != null && value is BuildType buildType)
+            if (entry.TryGetValue(TableKeyNames.BuildType, out var value) && value is BuildType buildType)
             {
                 content = buildType.ToString();
                 return true;

--- a/src/ProjectSystemTools/TableControl/DimensionsColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/DimensionsColumnDefinition.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.Dimensions, out var value) && value != null && 
+            if (entry.TryGetValue(TableKeyNames.Dimensions, out var value) &&
                 value is IEnumerable<string> dimensions &&
                 dimensions.Any())
             {

--- a/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
@@ -28,14 +28,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement content)
         {
-            if (entry.TryGetValue(TableKeyNames.Status, out var status) && status is BuildStatus and not BuildStatus.Running
-                && entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value is TimeSpan timeSpan)
+            if (TryCreateStringContent(entry, false, singleColumnView, out string text))
             {
                 content = new TextBlock
                 {
-                    Text = timeSpan.TotalSeconds.ToString("N3"),
+                    Text = text,
                     TextAlignment = TextAlignment.Right
                 };
+                return true;
+            }
+
+            content = null;
+            return false;
+        }
+
+        public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
+        {
+            if (entry.TryGetValue(TableKeyNames.Status, out var status) && status is BuildStatus and not BuildStatus.Running &&
+                entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value is TimeSpan timeSpan)
+            {
+                content = timeSpan.TotalSeconds.ToString("N3");
                 return true;
             }
 

--- a/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
@@ -28,9 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement content)
         {
-            if (entry.TryGetValue(TableKeyNames.Status, out var statusValue) && statusValue != null && statusValue is BuildStatus status
-                && status != BuildStatus.Running
-                && entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value != null && value is TimeSpan timeSpan)
+            if (entry.TryGetValue(TableKeyNames.Status, out var status) && status is BuildStatus and not BuildStatus.Running
+                && entry.TryGetValue(TableKeyNames.Elapsed, out var value) && value is TimeSpan timeSpan)
             {
                 content = new TextBlock
                 {

--- a/src/ProjectSystemTools/TableControl/ProjectTypeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ProjectTypeColumnDefinition.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.ProjectType, out var value) && value != null && value is string projectType)
+            if (entry.TryGetValue(TableKeyNames.ProjectType, out var value) && value is string projectType)
             {
                 content = projectType;
                 return true;

--- a/src/ProjectSystemTools/TableControl/StartTimeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/StartTimeColumnDefinition.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.StartTime, out var value) && value != null && value is DateTime startTime)
+            if (entry.TryGetValue(TableKeyNames.StartTime, out var value) && value is DateTime startTime)
             {
                 content = startTime.ToString("s");
                 return true;

--- a/src/ProjectSystemTools/TableControl/StatusColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/StatusColumnDefinition.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.Status, out var value) && value != null && value is BuildStatus status)
+            if (entry.TryGetValue(TableKeyNames.Status, out var value) && value is BuildStatus status)
             {
                 content = status.ToString();
                 return true;

--- a/src/ProjectSystemTools/TableControl/TimeColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/TimeColumnDefinition.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string content)
         {
-            if (entry.TryGetValue(TableKeyNames.Time, out var value) && value != null && value is DateTime time)
+            if (entry.TryGetValue(TableKeyNames.Time, out var value) && value is DateTime time)
             {
                 content = time.ToString("s");
                 return true;


### PR DESCRIPTION
Fixes #439 

Among the columns of the build logging table, the elapsed column was unique in how it provided values to the UI. The other columns provided a string value, while the elapsed column returned a `FrameworkElement` in order to right-align the column.

When copying the value to the clipboard, the platform's control doesn't know how to convert the `TextBlock` element into a string, so skips its value in the output.

The solution is to override both the `string`-providing method and the `FrameworkElement`-providing method.