### PR TITLE
Disable table menu items when nothing selected

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/UI/BuildLoggingToolWindow.cs
+++ b/src/ProjectSystemTools/BuildLogging/UI/BuildLoggingToolWindow.cs
@@ -198,6 +198,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 
         private void SaveLogs()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             using var folderBrowser = new FolderBrowserDialog()
             {
                 Description = BuildLoggingResources.LogFolderDescription
@@ -265,6 +267,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 
         public void OpenLog(ITableEntryHandle tableEntry)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             string? logPath = GetLogPath(tableEntry);
 
             if (logPath is not null)
@@ -326,6 +330,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.UI
 
         protected override int InnerQueryStatus(ref Guid commandGroupGuid, uint commandCount, OLECMD[] commands, IntPtr commandText)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (commandCount != 1 || commandGroupGuid != ProjectSystemToolsPackage.CommandSetGuid)
             {
                 return (int)Constants.OLECMDERR_E_NOTSUPPORTED;


### PR DESCRIPTION
This change made in response to confusion about the correct use of the UI seen on Twitter:

https://twitter.com/archiecoder/status/1598485876518096896

The user is trying to save a log file, but nothing is selected. We showed menu items that do nothing when clicked.

With this change, the menu items are only displayed when something will actually occur.