### PR TITLE
Validation won't fail the build

### DIFF
--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/Build.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -45,7 +46,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
         {
             if (Status != BuildStatus.Running)
             {
-                throw new InvalidOperationException();
+                // Just log the error. If we throw here, we may cause the build to fail.
+                // https://github.com/dotnet/project-system-tools/issues/467
+                Trace.WriteLine($"Build already finished with status {Status}.");
+                return;
             }
 
             BuildStatus newStatus = succeeded ? BuildStatus.Finished : BuildStatus.Failed;

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
                 {
                     if (_evaluations.TryGetValue(args.BuildEventContext.EvaluationId, out var evaluation))
                     {
-                        evaluation.Build.Finish(true, args.Timestamp);
+                        evaluation.Build.Finish(succeeded: true, args.Timestamp);
                         evaluation.Wrapper.RaiseEvent(sender, args);
                         evaluation.Wrapper.BinaryLogger.Shutdown();
                         evaluation.Build.SetLogPath(GetLogPath(evaluation.Build));


### PR DESCRIPTION
Fixes #467

If we receive a build finish notification more than once, don't throw an exception.

Unfortunately we don't know why this would occur, but it reportedly happened during a publish operation.

In such cases, it's not clear that we can do anything more useful than logging the error via tracing and continuing.