### PR TITLE
Add command and tool window icons

### DIFF
--- a/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/MessageToolListWindow.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor.ViewModel;
 using Microsoft.VisualStudio.ProjectSystem.Tools.TableControl;
@@ -136,6 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor
             AreMessagesShown = areMessagesShown;
 
             _monitorSelection = GetService(typeof(SVsShellMonitorSelection)) as IVsMonitorSelection;
+
+            BitmapImageMoniker = KnownMonikers.BuildErrorList;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.vsct
@@ -2,6 +2,7 @@
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <Extern href="stdidcmd.h"/>
   <Extern href="vsshlids.h"/>
+  <Include href="KnownImageIds.vsct"/>
   <Commands package="PackageGuid">
     <Menus>
       <Menu guid="UIGuid" id="BuildLoggingToolbarMenuId" priority="0x0000" type="ToolWindowToolbar">
@@ -37,6 +38,8 @@
     </Groups>
     <Buttons>
       <Button guid="CommandSetGuid" id="BuildLoggingCommandId" type="Button">
+        <Icon guid="ImageCatalogGuid" id="Log"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Build Logging</ButtonText>
         </Strings>
@@ -81,6 +84,8 @@
         </Strings>
       </Button>
       <Button guid="CommandSetGuid" id="MessageListCommandId" type="Button">
+        <Icon guid="ImageCatalogGuid" id="BuildErrorList" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Build Log Message List</ButtonText>
         </Strings>

--- a/src/ProjectSystemTools/TableControl/TableToolWindow.cs
+++ b/src/ProjectSystemTools/TableControl/TableToolWindow.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
@@ -41,6 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
             _contentWrapper = new ContentWrapper(ContextMenuId);
             Content = _contentWrapper;
+
+            BitmapImageMoniker = KnownMonikers.Log;
         }
 
         private static void OnFiltersChanged(object sender, FiltersChangedEventArgs e)


### PR DESCRIPTION
Until now, the "Build logging" and "Build message list" commands in the main menu appeared with no icon. This commit adds icons.

![image](https://user-images.githubusercontent.com/350947/208329110-8414759c-77d3-4f2a-8ab2-188f2a754eb3.png)
