### PR TITLE
Fix design-time build of ProjectSystemTools.csproj

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.3.0-2.final" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectSystemTools/BinaryLogEditor/ViewModel/SelectedObjectWrapper.cs
+++ b/src/ProjectSystemTools/BinaryLogEditor/ViewModel/SelectedObjectWrapper.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BinaryLogEditor.ViewModel
         public override PropertyDescriptorCollection GetProperties() => GetProperties(null);
 
         public override PropertyDescriptorCollection GetProperties(Attribute[]? attributes) =>
-            new PropertyDescriptorCollection(
+            new(
                 (from dictionary in _dictionaries
                  where dictionary.Value != null
                  from kvp in dictionary.Value

--- a/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Backend/EvaluationLogger.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.BackEnd
             public void RaiseEvent(object sender, BuildEventArgs args) => AnyEventRaised?.Invoke(sender, args);
         }
 
-        private readonly Dictionary<int, Evaluation> _evaluations = new Dictionary<int, Evaluation>();
+        private readonly Dictionary<int, Evaluation> _evaluations = new();
 
         public EvaluationLogger(BackEndBuildTableDataSource dataSource) :
             base(dataSource)

--- a/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.FrontEnd
 
         public bool IsLogging => _loggingController.IsLogging;
 
-        public bool SupportRoslynLogging { get; private set; }
+        public bool SupportRoslynLogging { get; }
 
         public void Start()
         {

--- a/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
+++ b/src/ProjectSystemTools/BuildLogging/Model/Frontend/FrontendBuildTableDataSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.BuildLogging.Model.FrontEnd
         private const string BuildTableDataSourceIdentifier = nameof(BuildTableDataSourceIdentifier);
         private const string BuildTableDataSourceSourceTypeIdentifier = nameof(BuildTableDataSourceSourceTypeIdentifier);
 
-        private readonly object _gate = new object();
+        private readonly object _gate = new();
 
         private ITableDataSink? _tableDataSink;
         private BuildTableEntriesSnapshot? _lastSnapshot;

--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -103,15 +103,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>BinaryLogEditorResources.resx</DependentUpon>
     </Compile>
-    <Compile Update="BinaryLogEditor\BuildTreeViewControl.xaml.cs">
-      <DependentUpon>BuildTreeViewControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="BinaryLogEditor\EvaluationTreeViewControl.xaml.cs">
-      <DependentUpon>EvaluationTreeViewControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="BinaryLogEditor\LogViewControl.xaml.cs">
-      <DependentUpon>LogViewControl.xaml</DependentUpon>
-    </Compile>
     <Compile Update="LogModel\Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>

--- a/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
+++ b/src/ProjectSystemTools/ProjectSystemToolsPackage.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
     {
         public const string PackageGuidString = "e3bfb509-b8fd-4692-b4c4-4b2f6ed62bc7";
 
-        public static readonly Guid CommandSetGuid = new Guid("cf0c6f43-4716-4419-93d0-2c246c8eb5ee");
+        public static readonly Guid CommandSetGuid = new("cf0c6f43-4716-4419-93d0-2c246c8eb5ee");
 
         public const int BuildLoggingCommandId = 0x0100;
         public const int StartLoggingCommandId = 0x0101;
@@ -47,17 +47,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools
 
         public const int LogRoslynWorkspaceStructureCommandId = 0x0200;
 
-        public static readonly Guid UIGuid = new Guid("629080DF-2A44-40E5-9AF4-371D4B727D16");
+        public static readonly Guid UIGuid = new("629080DF-2A44-40E5-9AF4-371D4B727D16");
 
         public const int BuildLoggingToolbarMenuId = 0x0100;
         public const int BuildLoggingContextMenuId = 0x0102;
         public const int MessageListToolbarMenuId = 0x0106;
 
         public const string BinaryLogEditorFactoryGuidString = "C5A2E7ED-F7E7-4199-BD68-17668AA2F2D4";
-        public static readonly Guid BinaryLogEditorFactoryGuid = new Guid(BinaryLogEditorFactoryGuidString);
+        public static readonly Guid BinaryLogEditorFactoryGuid = new(BinaryLogEditorFactoryGuidString);
 
         public const string BinaryLogEditorUIContextGuidString = "6B0A6B53-F2AA-41A6-AE25-7C7E8F2D2CAE";
-        public static readonly Guid BinaryLogEditorUIContextGuid = new Guid(BinaryLogEditorUIContextGuidString);
+        public static readonly Guid BinaryLogEditorUIContextGuid = new(BinaryLogEditorUIContextGuidString);
 
         private BuildLoggingToolWindow? _buildLoggingToolWindow;
 

--- a/src/ProjectSystemTools/RoslynLogging/RoslynWorkspaceStructureLogger.cs
+++ b/src/ProjectSystemTools/RoslynLogging/RoslynWorkspaceStructureLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.RoslynLogging
     internal static class RoslynWorkspaceStructureLogger
     {
         private static int s_NextCompilationId;
-        private static readonly ConditionalWeakTable<Compilation, StrongBox<int>> s_CompilationIds = new ConditionalWeakTable<Compilation, StrongBox<int>>();
+        private static readonly ConditionalWeakTable<Compilation, StrongBox<int>> s_CompilationIds = new();
 
         public static void ShowSaveDialogAndLog(IServiceProvider serviceProvider)
         {
@@ -442,7 +442,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.RoslynLogging
 
         private sealed class ThreadedWaitCallback : IVsThreadedWaitDialogCallback
         {
-            private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+            private readonly CancellationTokenSource _cancellationTokenSource = new();
 
             public CancellationToken CancellationToken
             {

--- a/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
+++ b/src/ProjectSystemTools/TableControl/ElapsedColumnDefinition.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tools.TableControl
 
         public override double MinWidth => 60.0;
 
-        public override GridLength ColumnDefinition => new GridLength(60);
+        public override GridLength ColumnDefinition => new(60);
 
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 


### PR DESCRIPTION
Remove explicit reference to old compiler toolset. This old version does not specify all required MSBuild properties, resulting in a failure when opening the project in Visual Studio.

Also some minor tidy up to remove hints from IDE.