### PR TITLE
Add DefaultDllImportSearchPaths

### DIFF
--- a/src/ProjectSystemTools/GlobalAssemblyInfo.cs
+++ b/src/ProjectSystemTools/GlobalAssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All Rights Reserved. Licensed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.InteropServices;
+// Ensure P/Invokes from within this assembly only load libraries from trusted and safe paths.
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]


### PR DESCRIPTION
Related #1853770.

Use the `DefaultDllImportSearchPaths` attribute to ensure that P/Invokes (if any) from within this assembly only load native libraries from trusted and safe paths.