### PR TITLE
Remove incompatible code sign check

### DIFF
--- a/eng/analyze-compliance.yml
+++ b/eng/analyze-compliance.yml
@@ -10,16 +10,6 @@ parameters:
 # - InferSharp: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1638/InferSharp-Usage
 # - CodeQL: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/codeql-build-task
 steps:
-# Verify the loose DLLs are signed appropriately.
-# Note: This task takes ~3 minutes only because it is the first Guardian task in this job. So, it installs the Guardian components so the other tasks don't have to.
-# YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/code-signing-validation-build-task#v1-preview
-- task: CodeSign@1
-  displayName: Verify Signed DLLs
-  inputs:
-    Path: $(Build.SourcesDirectory)/artifacts/DLLs/
-    # Glob Format: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1378/Glob-Format
-    Targets: '**.dll'
-  condition: succeededOrFailed()
 
 # Scan for the use of undocumented APIs.
 # YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#v2


### PR DESCRIPTION
[pipeline run](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9488299&view=results)

This code signing validation is incompatible with Arcade pipelines. It is causing `CodeSign.MissingSigningCert` on all of the `.dll` that are in fact signed. This is because this code sign validation doesn't work with how this Arcade repo is signed. Thus, this code sign validation needs to be removed because it is an invalid check.

Signing is done here with the singing plugin and during build here: 

https://github.com/dotnet/project-system-tools/blob/main/eng/common/templates-official/job/job.yml#L131

https://github.com/dotnet/project-system-tools/blob/7b89ddee00a91d80e54a7345d83e51a490c29309/eng/common/build.ps1#L60

I have manually verified that the `.dll`s are in fact being signed. For example, we can see that the `Microsoft.VisualStudio.ProjectSystem.Tools.dll` is being signed here:
![projectsystemtools](https://github.com/dotnet/project-system-tools/assets/111816896/236f7822-ffef-42ab-b2e4-f868c46de163)
![projectsystemtoolsagain](https://github.com/dotnet/project-system-tools/assets/111816896/76de5791-c9e0-425c-aeb0-3d7f3bb33146)


Originally, this validation was copied over from a non-Arcade pipeline during the 1ES pipeline migration. In the future, we want to use Arcade signing validation in our pipeline; I created #487 to track.