### PR TITLE
[Experimental] Remove legacy BuildEngine reference

### DIFF
--- a/src/ProjectSystemTools/ProjectSystemTools.csproj
+++ b/src/ProjectSystemTools/ProjectSystemTools.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />


### PR DESCRIPTION
### Context

MSBuild team is planning to remove the deprecated package Microsoft.Build.Engine (https://github.com/dotnet/msbuild/issues/8826).
The package referenced here doesn't seem to be actually used - so let's temove it.