### PR TITLE
Update xcopy-msbuild and vs to latest available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "vs": {
       "version": "16.8"
     },
-    "xcopy-msbuild": "16.8.0-preview2.1"
+    "xcopy-msbuild": "17.13.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25120.6"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "tools": {
     "vs": {
-      "version": "16.8"
+      "version": "17.13"
     },
     "xcopy-msbuild": "17.13.0"
   },


### PR DESCRIPTION
Updated xcopy-msbuild in global.json to the latest available version on dotnet-eng
Updated vs to the [latest available version](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes-v17.13)

I am raising this as I made the change in [aspnetcore](https://github.com/dotnet/aspnetcore) via https://github.com/dotnet/aspnetcore/pull/60666 and spotted this repository was using an older preview version of 16.x